### PR TITLE
implement TextTagElement parameters in subclass renderers

### DIFF
--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
@@ -27,10 +27,11 @@ public class ComponentTagElement extends TextTagElement {
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         int height = 0;
-        for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, width - 10)) {
+        Component renderText = text.copy().setStyle(this.getStyle().applyTo(text.getStyle()));
+        for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(renderText, width - 10)) {
             graphics.drawString(
                 Minecraft.getInstance().font,
-                sequence, x, y + height, this.color.getValue(),
+                sequence, getXOffset(x, width, sequence), y + height, this.color.getValue(),
                 this.shadowed
             );
             height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -20,12 +20,12 @@ public class HeadingOneTagElement extends TextTagElement {
         try (var ignored = new CloseablePoseStack(graphics)) {
             graphics.pose().scale(3, 3, 3);
             graphics.pose().translate(-x / 1.5f, -y / 1.5f, 0);
-            Component text = Component.nullToEmpty(this.content);
+            Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             int height = 0;
             for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, width - 10)) {
                 graphics.drawString(
                     Minecraft.getInstance().font,
-                    sequence, x + 2, y + height, this.color.getValue(),
+                    sequence, getXOffset(x + 2, width, sequence), y + height, this.color.getValue(),
                     false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -20,12 +20,12 @@ public class HeadingTwoTagElement extends TextTagElement {
         try (var ignored = new CloseablePoseStack(graphics)) {
             graphics.pose().scale(2, 2, 2);
             graphics.pose().translate(-x / 2f, -y / 2f, 0);
-            Component text = Component.nullToEmpty(this.content);
+            Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             int height = 0;
             for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, width - 10)) {
                 graphics.drawString(
                     Minecraft.getInstance().font,
-                    sequence, x + 2, y + height, this.color.getValue(),
+                    sequence, getXOffset(x + 2, width, sequence), y + height, this.color.getValue(),
                     false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
@@ -16,7 +16,7 @@ public class ParagraphTagElement extends TextTagElement {
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
-        Component text = Component.nullToEmpty(this.content);
+        Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
         int height = 0;
         for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, width - 5)) {
             graphics.drawString(

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
@@ -3,34 +3,36 @@ package earth.terrarium.hermes.api.defaults;
 import com.teamresourceful.resourcefullib.common.color.Color;
 import earth.terrarium.hermes.api.TagElement;
 import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Style;
 import net.minecraft.util.FormattedCharSequence;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
 public abstract class TextTagElement implements TagElement {
 
     protected String content = "";
-    protected boolean bold;
-    protected boolean italic;
-    protected boolean underline;
-    protected boolean strikethrough;
-    protected boolean obfuscated;
+    protected @Nullable Boolean bold;
+    protected @Nullable Boolean italic;
+    protected @Nullable Boolean underline;
+    protected @Nullable Boolean strikethrough;
+    protected @Nullable Boolean obfuscated;
     protected boolean centered;
     protected boolean shadowed;
     protected Color color;
 
     protected TextTagElement(Map<String, String> parameters) {
-        this.bold = parameters.containsKey("bold") && Boolean.parseBoolean(parameters.get("bold"));
-        this.italic = parameters.containsKey("italic") && Boolean.parseBoolean(parameters.get("italic"));
-        this.underline = parameters.containsKey("underline") && Boolean.parseBoolean(parameters.get("underline"));
-        this.strikethrough = parameters.containsKey("strikethrough") && Boolean.parseBoolean(parameters.get("strikethrough"));
-        this.obfuscated = parameters.containsKey("obfuscated") && Boolean.parseBoolean(parameters.get("obfuscated"));
+        this.bold = parameters.containsKey("bold") ? Boolean.parseBoolean(parameters.get("bold")) : null;
+        this.italic = parameters.containsKey("italic") ? Boolean.parseBoolean(parameters.get("italic")) : null;
+        this.underline = parameters.containsKey("underline") ? Boolean.parseBoolean(parameters.get("underline")) : null;
+        this.strikethrough = parameters.containsKey("strikethrough") ? Boolean.parseBoolean(parameters.get("strikethrough")) : null;
+        this.obfuscated = parameters.containsKey("obfuscated") ? Boolean.parseBoolean(parameters.get("obfuscated")) : null;
         this.centered = parameters.containsKey("centered") && Boolean.parseBoolean(parameters.get("centered"));
         this.shadowed = parameters.containsKey("shadowed") && Boolean.parseBoolean(parameters.get("shadowed"));
         if (parameters.containsKey("color")) {
             try {
                 this.color = Color.parse(parameters.get("color"));
-            } catch (Exception e) {
+            } catch (Exception ignored) {
                 this.color = Color.DEFAULT;
             }
         } else {
@@ -44,6 +46,15 @@ public abstract class TextTagElement implements TagElement {
     }
 
     public int getXOffset(int x, int width, FormattedCharSequence text) {
-        return this.centered ? x + (width - Minecraft.getInstance().font.width(text)) / 2 : x;
+        return Boolean.TRUE.equals(this.centered) ? x + (width - Minecraft.getInstance().font.width(text)) / 2 : x;
+    }
+
+    public Style getStyle() {
+        return Style.EMPTY
+                .withBold(bold)
+                .withItalic(italic)
+                .withUnderlined(underline)
+                .withStrikethrough(strikethrough)
+                .withObfuscated(obfuscated);
     }
 }


### PR DESCRIPTION
Also gives TextTagElement a concept of `inherit` like normal styles do. This means the type of these fields have changed to `Boolean`, breaking dependent subclasses of TextTagElement that actually use them (I haven't seen any).

tldr this makes parameters like `bold="true"` actually work by applying them as a style to the relevant components.