### PR TITLE
add overscroll to DocumentWidget

### DIFF
--- a/common/src/main/java/earth/terrarium/hermes/client/DocumentWidget.java
+++ b/common/src/main/java/earth/terrarium/hermes/client/DocumentWidget.java
@@ -23,6 +23,8 @@ public class DocumentWidget extends AbstractContainerEventHandler implements Ren
     private final int y;
     private final int width;
     private final int height;
+    private final double overscrollTop;
+    private final double overscrollBottom;
 
     private double scrollAmount;
     private int lastFullHeight;
@@ -30,14 +32,21 @@ public class DocumentWidget extends AbstractContainerEventHandler implements Ren
     //We have to defer the mouse click until during render because we don't know the height of the document until then.
     private DocumentMouse mouse = null;
 
-    public DocumentWidget(int x, int y, int width, int height, Theme theme, List<TagElement> elements) {
+    public DocumentWidget(int x, int y, int width, int height, double overscrollTop, double overscrollBottom, Theme theme, List<TagElement> elements) {
         this.x = x;
         this.y = y;
         this.width = width - 6;
         this.height = height - 6;
+        this.overscrollTop = overscrollTop;
+        this.overscrollBottom = overscrollBottom;
         this.lastFullHeight = this.height;
         this.theme = theme;
         this.elements.addAll(elements);
+        this.scrollAmount = -overscrollTop;
+    }
+
+    public DocumentWidget(int x, int y, int width, int height, Theme theme, List<TagElement> elements) {
+        this(x, y, width, height, 0.0D, 0.0D, theme, elements);
     }
 
     @Override
@@ -59,12 +68,11 @@ public class DocumentWidget extends AbstractContainerEventHandler implements Ren
             this.mouse = null;
             this.lastFullHeight = fullHeight;
         }
-        this.scrollAmount = Mth.clamp(this.scrollAmount, 0.0D, Math.max(0, this.lastFullHeight - this.height));
     }
 
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double scrollAmount) {
-        this.scrollAmount = Mth.clamp(this.scrollAmount - scrollAmount * 10, 0.0D, Math.max(0, this.lastFullHeight - this.height));
+        this.scrollAmount = Mth.clamp(this.scrollAmount - scrollAmount * 10, -overscrollTop, Math.max(-overscrollTop, this.lastFullHeight - this.height + overscrollBottom));
         return true;
     }
 


### PR DESCRIPTION
Gives documentwidget "overscroll", giving it effectively an internal margin. The initial scroll state is overscrolled as high as possible.

This allows for a document to take up the full space inside an area, preventing multi-line widgets from appearing cut off, while still appearing to have the correct margins when that space is unneeded.

This scroll pattern is also used for other full-tab widgets like the task and reward list in heracles, but I didn't see it fit to generify it here. Let me know if i should and how!

Example of a 5-unit top-and-bottom overscroll being used to avoid cut-off spots in a heracles overview:

https://github.com/terrarium-earth/Hermes/assets/55819817/3e29d54e-a6c9-4759-9c4e-94a093f18fca

