### PR TITLE
Fix incorrect wrapping width in Heading{One,Two}TagElement

### DIFF
--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -22,7 +22,7 @@ public class HeadingOneTagElement extends TextTagElement {
             graphics.pose().translate(-x / 1.5f, -y / 1.5f, 0);
             Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             int height = 0;
-            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, width - 10)) {
+            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / 3)) {
                 graphics.drawString(
                     Minecraft.getInstance().font,
                     sequence, getXOffset(x + 2, width, sequence), y + height, this.color.getValue(),
@@ -35,7 +35,7 @@ public class HeadingOneTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), width - 10).size();
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / 3).size();
         return lines * (Minecraft.getInstance().font.lineHeight + 1) * 3;
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -22,7 +22,7 @@ public class HeadingTwoTagElement extends TextTagElement {
             graphics.pose().translate(-x / 2f, -y / 2f, 0);
             Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             int height = 0;
-            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, width - 10)) {
+            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / 2)) {
                 graphics.drawString(
                     Minecraft.getInstance().font,
                     sequence, getXOffset(x + 2, width, sequence), y + height, this.color.getValue(),
@@ -35,7 +35,7 @@ public class HeadingTwoTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), width - 10).size();
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / 2).size();
         return lines * (Minecraft.getInstance().font.lineHeight + 1) * 2;
     }
 }


### PR DESCRIPTION
Fixes terrarium-earth/Heracles#98

Since text in heading elements are scaled, we have to divide the available width by the scale.

In the future, we might want to refactor the common logic between these two classes (and perhaps others).