### PR TITLE
Fix attribute behavior for <h1> and <h2> (both centered="true" and shadowed="true")

### DIFF
--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -26,7 +26,7 @@ public class HeadingOneTagElement extends TextTagElement {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, sequence), y + height,
+                    getXOffset(x + 2, width, 3, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -28,7 +28,7 @@ public class HeadingOneTagElement extends TextTagElement {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x, width, SCALE, sequence), y + height,
+                    getXOffset(x, width, sequence), y + height,
                     this.color, this.shadowed
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;
@@ -40,5 +40,11 @@ public class HeadingOneTagElement extends TextTagElement {
     public int getHeight(int width) {
         int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / SCALE).size();
         return lines * (Minecraft.getInstance().font.lineHeight + 1) * SCALE;
+    }
+
+    @Override
+    public int getXOffset(int x, int width, FormattedCharSequence text) {
+        int textWidth = SCALE * Minecraft.getInstance().font.width(text);
+        return Boolean.TRUE.equals(this.centered) ? x + (int) ((((width - textWidth) / 2f) / SCALE) + 0.5f) : x;
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -28,7 +28,7 @@ public class HeadingOneTagElement extends TextTagElement {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, SCALE, sequence), y + height,
+                    getXOffset(x, width, SCALE, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -29,7 +29,7 @@ public class HeadingOneTagElement extends TextTagElement {
                     graphics,
                     sequence,
                     getXOffset(x, width, SCALE, sequence), y + height,
-                    this.color, false
+                    this.color, this.shadowed
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;
             }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -11,6 +11,8 @@ import java.util.Map;
 
 public class HeadingOneTagElement extends TextTagElement {
 
+    private static final int SCALE = 3;
+
     public HeadingOneTagElement(Map<String, String> parameters) {
         super(parameters);
     }
@@ -18,15 +20,15 @@ public class HeadingOneTagElement extends TextTagElement {
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var ignored = new CloseablePoseStack(graphics)) {
-            graphics.pose().scale(3, 3, 3);
+            graphics.pose().scale(SCALE, SCALE, SCALE);
             graphics.pose().translate(-x / 1.5f, -y / 1.5f, 0);
             Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             int height = 0;
-            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / 3)) {
+            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / SCALE)) {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, 3, sequence), y + height,
+                    getXOffset(x + 2, width, SCALE, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;
@@ -36,7 +38,7 @@ public class HeadingOneTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / 3).size();
-        return lines * (Minecraft.getInstance().font.lineHeight + 1) * 3;
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / SCALE).size();
+        return lines * (Minecraft.getInstance().font.lineHeight + 1) * SCALE;
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -27,7 +27,7 @@ public class HeadingTwoTagElement extends TextTagElement {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, SCALE, sequence), y + height,
+                    getXOffset(x, width, SCALE, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -26,7 +26,7 @@ public class HeadingTwoTagElement extends TextTagElement {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, sequence), y + height,
+                    getXOffset(x + 2, width, 2, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -28,7 +28,7 @@ public class HeadingTwoTagElement extends TextTagElement {
                     graphics,
                     sequence,
                     getXOffset(x, width, SCALE, sequence), y + height,
-                    this.color, false
+                    this.color, this.shadowed
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;
             }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public class HeadingTwoTagElement extends TextTagElement {
 
+    private static final int SCALE = 2;
     public HeadingTwoTagElement(Map<String, String> parameters) {
         super(parameters);
     }
@@ -18,15 +19,15 @@ public class HeadingTwoTagElement extends TextTagElement {
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var ignored = new CloseablePoseStack(graphics)) {
-            graphics.pose().scale(2, 2, 2);
+            graphics.pose().scale(SCALE, SCALE, SCALE);
             graphics.pose().translate(-x / 2f, -y / 2f, 0);
             Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             int height = 0;
-            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / 2)) {
+            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / SCALE)) {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, 2, sequence), y + height,
+                    getXOffset(x + 2, width, SCALE, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;
@@ -36,7 +37,7 @@ public class HeadingTwoTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / 2).size();
-        return lines * (Minecraft.getInstance().font.lineHeight + 1) * 2;
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / SCALE).size();
+        return lines * (Minecraft.getInstance().font.lineHeight + 1) * SCALE;
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -12,6 +12,7 @@ import java.util.Map;
 public class HeadingTwoTagElement extends TextTagElement {
 
     private static final int SCALE = 2;
+
     public HeadingTwoTagElement(Map<String, String> parameters) {
         super(parameters);
     }
@@ -27,7 +28,7 @@ public class HeadingTwoTagElement extends TextTagElement {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x, width, SCALE, sequence), y + height,
+                    getXOffset(x, width, sequence), y + height,
                     this.color, this.shadowed
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;
@@ -39,5 +40,11 @@ public class HeadingTwoTagElement extends TextTagElement {
     public int getHeight(int width) {
         int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / SCALE).size();
         return lines * (Minecraft.getInstance().font.lineHeight + 1) * SCALE;
+    }
+
+    @Override
+    public int getXOffset(int x, int width, FormattedCharSequence text) {
+        int textWidth = SCALE * Minecraft.getInstance().font.width(text);
+        return Boolean.TRUE.equals(this.centered) ? x + (int) ((((width - textWidth) / 2f) / SCALE) + 0.5f) : x;
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
@@ -49,11 +49,6 @@ public abstract class TextTagElement implements TagElement {
         return Boolean.TRUE.equals(this.centered) ? x + (width - Minecraft.getInstance().font.width(text)) / 2 : x;
     }
 
-    public int getXOffset(int x, int width, int scale, FormattedCharSequence text) {
-        int textWidth = scale * Minecraft.getInstance().font.width(text);
-        return Boolean.TRUE.equals(this.centered) ? x + (int) ((((width - textWidth) / 2f) / scale) + 0.5f) : x;
-    }
-
     public Style getStyle() {
         return Style.EMPTY
                 .withBold(bold)

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
@@ -49,6 +49,11 @@ public abstract class TextTagElement implements TagElement {
         return Boolean.TRUE.equals(this.centered) ? x + (width - Minecraft.getInstance().font.width(text)) / 2 : x;
     }
 
+    public int getXOffset(int x, int width, int scale, FormattedCharSequence text) {
+        int textWidth = scale * Minecraft.getInstance().font.width(text);
+        return Boolean.TRUE.equals(this.centered) ? x + (int) ((((width - textWidth) / 2f) / scale) + 0.5f) : x;
+    }
+
     public Style getStyle() {
         return Style.EMPTY
                 .withBold(bold)


### PR DESCRIPTION
_[Updated screen detail with one that shows the full width of the horizontal rule, though the game aim cross-hair is a good reference point for centering in a quest view without the left margin showing, as is this one.]_

With some bonus consolidation of a constant value, and a further small fix to placement for `<h1>` and `<h2>`.

After: 
<img width="660" alt="image" src="https://github.com/terrarium-earth/Hermes/assets/6677700/c04a1b88-d148-43c6-ad35-350d1979dbf1">


Closes Issue #13, which has a before shot there.