### PR TITLE
Fix attribute behavior for <h1> and <h2> (both centered="true" and shadowed="true") 

### DIFF
--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -26,7 +26,7 @@ public class HeadingOneTagElement extends TextTagElement {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, sequence), y + height,
+                    getXOffset(x + 2, width, 3, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -1,44 +1,9 @@
 package earth.terrarium.hermes.api.defaults;
 
-import com.teamresourceful.resourcefullib.client.CloseablePoseStack;
-import earth.terrarium.hermes.api.themes.Theme;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.chat.Component;
-import net.minecraft.util.FormattedCharSequence;
-
 import java.util.Map;
 
-public class HeadingOneTagElement extends TextTagElement {
+public class HeadingOneTagElement extends HeadingTagElement {
 
-    private static final int SCALE = 3;
+    public HeadingOneTagElement(Map<String, String> parameters) { super(parameters, 3); }
 
-    public HeadingOneTagElement(Map<String, String> parameters) {
-        super(parameters);
-    }
-
-    @Override
-    public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
-        try (var ignored = new CloseablePoseStack(graphics)) {
-            graphics.pose().scale(SCALE, SCALE, SCALE);
-            graphics.pose().translate(-x / 1.5f, -y / 1.5f, 0);
-            Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
-            int height = 0;
-            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / SCALE)) {
-                theme.drawText(
-                    graphics,
-                    sequence,
-                    getXOffset(x, width, SCALE, sequence), y + height,
-                    this.color, this.shadowed
-                );
-                height += Minecraft.getInstance().font.lineHeight + 1;
-            }
-        }
-    }
-
-    @Override
-    public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / SCALE).size();
-        return lines * (Minecraft.getInstance().font.lineHeight + 1) * SCALE;
-    }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -28,7 +28,7 @@ public class HeadingOneTagElement extends TextTagElement {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, SCALE, sequence), y + height,
+                    getXOffset(x, width, SCALE, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -29,7 +29,7 @@ public class HeadingOneTagElement extends TextTagElement {
                     graphics,
                     sequence,
                     getXOffset(x, width, SCALE, sequence), y + height,
-                    this.color, false
+                    this.color, this.shadowed
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;
             }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingOneTagElement.java
@@ -11,6 +11,8 @@ import java.util.Map;
 
 public class HeadingOneTagElement extends TextTagElement {
 
+    private static final int SCALE = 3;
+
     public HeadingOneTagElement(Map<String, String> parameters) {
         super(parameters);
     }
@@ -18,15 +20,15 @@ public class HeadingOneTagElement extends TextTagElement {
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var ignored = new CloseablePoseStack(graphics)) {
-            graphics.pose().scale(3, 3, 3);
+            graphics.pose().scale(SCALE, SCALE, SCALE);
             graphics.pose().translate(-x / 1.5f, -y / 1.5f, 0);
             Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             int height = 0;
-            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / 3)) {
+            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / SCALE)) {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, 3, sequence), y + height,
+                    getXOffset(x + 2, width, SCALE, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;
@@ -36,7 +38,7 @@ public class HeadingOneTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / 3).size();
-        return lines * (Minecraft.getInstance().font.lineHeight + 1) * 3;
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / SCALE).size();
+        return lines * (Minecraft.getInstance().font.lineHeight + 1) * SCALE;
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
@@ -21,7 +21,7 @@ public abstract class HeadingTagElement extends TextTagElement {
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var ignored = new CloseablePoseStack(graphics)) {
             graphics.pose().scale(SCALE, SCALE, SCALE);
-            float translationFactor = 1 - (1f / SCALE);
+            float translationFactor = 1 + (1f / (SCALE - 1));
             graphics.pose().translate(-x / translationFactor, -y / translationFactor, 0);
             Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             int height = 0;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
@@ -11,21 +11,22 @@ import java.util.Map;
 
 public abstract class HeadingTagElement extends TextTagElement {
 
-    public final int SCALE;
+    public final int scale;
+
     public HeadingTagElement(Map<String, String> parameters, int scale) {
         super(parameters);
-        this.SCALE = scale;
+        this.scale = scale;
     }
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var ignored = new CloseablePoseStack(graphics)) {
-            graphics.pose().scale(SCALE, SCALE, SCALE);
-            float translationFactor = 1 + (1f / (SCALE - 1));
+            graphics.pose().scale(scale, scale, scale);
+            float translationFactor = 1 + (1f / (scale - 1));
             graphics.pose().translate(-x / translationFactor, -y / translationFactor, 0);
             Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             int height = 0;
-            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / SCALE)) {
+            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / scale)) {
                 theme.drawText(
                         graphics,
                         sequence,
@@ -39,13 +40,13 @@ public abstract class HeadingTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / SCALE).size();
-        return lines * (Minecraft.getInstance().font.lineHeight + 1) * SCALE;
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / scale).size();
+        return lines * (Minecraft.getInstance().font.lineHeight + 1) * scale;
     }
 
     @Override
     public int getXOffset(int x, int width, FormattedCharSequence text) {
-        int textWidth = SCALE * Minecraft.getInstance().font.width(text);
-        return Boolean.TRUE.equals(this.centered) ? x + (int) ((((width - textWidth) / 2f) / SCALE) + 0.5f) : x;
+        int textWidth = scale * Minecraft.getInstance().font.width(text);
+        return Boolean.TRUE.equals(this.centered) ? x + (int) ((((width - textWidth) / 2f) / scale) + 0.5f) : x;
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
@@ -1,0 +1,51 @@
+package earth.terrarium.hermes.api.defaults;
+
+import com.teamresourceful.resourcefullib.client.CloseablePoseStack;
+import earth.terrarium.hermes.api.themes.Theme;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.FormattedCharSequence;
+
+import java.util.Map;
+
+public abstract class HeadingTagElement extends TextTagElement {
+
+    public final int SCALE;
+    public HeadingTagElement(Map<String, String> parameters, int scale) {
+        super(parameters);
+        this.SCALE = scale;
+    }
+
+    @Override
+    public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
+        try (var ignored = new CloseablePoseStack(graphics)) {
+            graphics.pose().scale(SCALE, SCALE, SCALE);
+            float translationFactor = 1 - (1f / SCALE);
+            graphics.pose().translate(-x / translationFactor, -y / translationFactor, 0);
+            Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
+            int height = 0;
+            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / SCALE)) {
+                theme.drawText(
+                        graphics,
+                        sequence,
+                        getXOffset(x, width, sequence), y + height,
+                        this.color, this.shadowed
+                );
+                height += Minecraft.getInstance().font.lineHeight + 1;
+            }
+        }
+    }
+
+    @Override
+    public int getHeight(int width) {
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / SCALE).size();
+        return lines * (Minecraft.getInstance().font.lineHeight + 1) * SCALE;
+    }
+
+    @Override
+    public int getXOffset(int x, int width, FormattedCharSequence text) {
+        int textWidth = SCALE * Minecraft.getInstance().font.width(text);
+        return Boolean.TRUE.equals(this.centered) ? x + (int) ((((width - textWidth) / 2f) / SCALE) + 0.5f) : x;
+    }
+}

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -27,7 +27,7 @@ public class HeadingTwoTagElement extends TextTagElement {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, SCALE, sequence), y + height,
+                    getXOffset(x, width, SCALE, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -26,7 +26,7 @@ public class HeadingTwoTagElement extends TextTagElement {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, sequence), y + height,
+                    getXOffset(x + 2, width, 2, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -1,43 +1,11 @@
 package earth.terrarium.hermes.api.defaults;
 
-import com.teamresourceful.resourcefullib.client.CloseablePoseStack;
-import earth.terrarium.hermes.api.themes.Theme;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.chat.Component;
-import net.minecraft.util.FormattedCharSequence;
-
 import java.util.Map;
 
-public class HeadingTwoTagElement extends TextTagElement {
+public class HeadingTwoTagElement extends HeadingTagElement {
 
-    private static final int SCALE = 2;
     public HeadingTwoTagElement(Map<String, String> parameters) {
-        super(parameters);
+        super(parameters, 2);
     }
 
-    @Override
-    public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
-        try (var ignored = new CloseablePoseStack(graphics)) {
-            graphics.pose().scale(SCALE, SCALE, SCALE);
-            graphics.pose().translate(-x / 2f, -y / 2f, 0);
-            Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
-            int height = 0;
-            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / SCALE)) {
-                theme.drawText(
-                    graphics,
-                    sequence,
-                    getXOffset(x, width, SCALE, sequence), y + height,
-                    this.color, this.shadowed
-                );
-                height += Minecraft.getInstance().font.lineHeight + 1;
-            }
-        }
-    }
-
-    @Override
-    public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / SCALE).size();
-        return lines * (Minecraft.getInstance().font.lineHeight + 1) * SCALE;
-    }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -28,7 +28,7 @@ public class HeadingTwoTagElement extends TextTagElement {
                     graphics,
                     sequence,
                     getXOffset(x, width, SCALE, sequence), y + height,
-                    this.color, false
+                    this.color, this.shadowed
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;
             }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTwoTagElement.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public class HeadingTwoTagElement extends TextTagElement {
 
+    private static final int SCALE = 2;
     public HeadingTwoTagElement(Map<String, String> parameters) {
         super(parameters);
     }
@@ -18,15 +19,15 @@ public class HeadingTwoTagElement extends TextTagElement {
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var ignored = new CloseablePoseStack(graphics)) {
-            graphics.pose().scale(2, 2, 2);
+            graphics.pose().scale(SCALE, SCALE, SCALE);
             graphics.pose().translate(-x / 2f, -y / 2f, 0);
             Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             int height = 0;
-            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / 2)) {
+            for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, (width - 10) / SCALE)) {
                 theme.drawText(
                     graphics,
                     sequence,
-                    getXOffset(x + 2, width, 2, sequence), y + height,
+                    getXOffset(x + 2, width, SCALE, sequence), y + height,
                     this.color, false
                 );
                 height += Minecraft.getInstance().font.lineHeight + 1;
@@ -36,7 +37,7 @@ public class HeadingTwoTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / 2).size();
-        return lines * (Minecraft.getInstance().font.lineHeight + 1) * 2;
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / SCALE).size();
+        return lines * (Minecraft.getInstance().font.lineHeight + 1) * SCALE;
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
@@ -49,11 +49,6 @@ public abstract class TextTagElement implements TagElement {
         return Boolean.TRUE.equals(this.centered) ? x + (width - Minecraft.getInstance().font.width(text)) / 2 : x;
     }
 
-    public int getXOffset(int x, int width, int scale, FormattedCharSequence text) {
-        int textWidth = scale * Minecraft.getInstance().font.width(text);
-        return Boolean.TRUE.equals(this.centered) ? x + (int) ((((width - textWidth) / 2f) / scale) + 0.5f) : x;
-    }
-
     public Style getStyle() {
         return Style.EMPTY
                 .withBold(bold)

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
@@ -49,6 +49,11 @@ public abstract class TextTagElement implements TagElement {
         return Boolean.TRUE.equals(this.centered) ? x + (width - Minecraft.getInstance().font.width(text)) / 2 : x;
     }
 
+    public int getXOffset(int x, int width, int scale, FormattedCharSequence text) {
+        int textWidth = scale * Minecraft.getInstance().font.width(text);
+        return Boolean.TRUE.equals(this.centered) ? x + (int) ((((width - textWidth) / 2f) / scale) + 0.5f) : x;
+    }
+
     public Style getStyle() {
         return Style.EMPTY
                 .withBold(bold)


### PR DESCRIPTION
1. Makes `centered="true"` and `shadowed="true"` both work (separately or together) for `<h1>` and `<h2>` elements.
2. Consolidates common code from `HeadingOneTagElement` and `HeadingTwoTagElement` into new, parent `HeadingTagElement` class

**Before:**
<img width="627" alt="Screenshot 2023-12-11 at 9 02 05 PM" src="https://github.com/terrarium-earth/Hermes/assets/6677700/86a545ca-942e-4347-be3e-42c47f371e2b">

**After:**
<img width="625" alt="Screenshot 2023-12-11 at 9 04 15 PM" src="https://github.com/terrarium-earth/Hermes/assets/6677700/04f563b9-75fa-4e71-a02d-bb11fa2b1b17">

