### PR TITLE
"scale" and "height" attributes for <entity> elements

### DIFF
--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
@@ -17,11 +17,13 @@ public class EntityTagElement implements TagElement {
 
     private final EntityType<?> type;
     private final CompoundTag tag;
+    private final float scale;
     private Entity entity;
 
     public EntityTagElement(Map<String, String> parameters) {
         this.type = ElementParsingUtils.parseEntityType(parameters, "type", null);
         this.tag = ElementParsingUtils.parseTag(parameters, "tag", null);
+        this.scale = ElementParsingUtils.parseFloat(parameters, "scale", 1.0f);
     }
 
     @Override
@@ -33,14 +35,16 @@ public class EntityTagElement implements TagElement {
                     entity.load(tag);
                 }
             }
+            int renderHeight = (int) (25 * scale);
+            int offsetY = getHeight(width) - (int) (3 * scale);
             if (entity instanceof LivingEntity living) {
-                InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, x + (int) (width / 2f), y + 47, 25, x + (int) (width / 2f) - mouseX, y + 47 - mouseY, living);
+                InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, x + (int) (width / 2f), y + offsetY, renderHeight, x + (int) (width / 2f) - mouseX, y + 47 - mouseY, living);
             }
         }
     }
 
     @Override
     public int getHeight(int width) {
-        return 50;
+        return (int) (50 * scale);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
@@ -17,6 +17,7 @@ public class EntityTagElement implements TagElement {
 
     private final EntityType<?> type;
     private final CompoundTag tag;
+    private final static int BLOCK_HEIGHT = 25;
     private final float scale;
     private Entity entity;
 
@@ -35,16 +36,18 @@ public class EntityTagElement implements TagElement {
                     entity.load(tag);
                 }
             }
-            int renderHeight = (int) (25 * scale);
-            int offsetY = getHeight(width) - (int) (3 * scale);
             if (entity instanceof LivingEntity living) {
-                InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, x + (int) (width / 2f), y + offsetY, renderHeight, x + (int) (width / 2f) - mouseX, y + 47 - mouseY, living);
+                int blockScale = (int) ((BLOCK_HEIGHT * scale) + 0.5f);
+                int offsetX = x + (int) ((width / 2f) + 0.5f);
+                int offsetY = y + (int) ((blockScale * 2) + 0.5f);
+                int eyeOffset = offsetY - (int) ((living.getEyeHeight() * blockScale) + 0.5f);
+                InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, offsetX, offsetY, blockScale, offsetX - mouseX, eyeOffset - mouseY, living);
             }
         }
     }
 
     @Override
     public int getHeight(int width) {
-        return (int) (50 * scale);
+        return (int) ((2 * BLOCK_HEIGHT * scale) + 3 + 0.5f);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
@@ -19,12 +19,14 @@ public class EntityTagElement implements TagElement {
     private final CompoundTag tag;
     private final static int BLOCK_HEIGHT = 25;
     private final float scale;
+    private float height;
     private Entity entity;
 
     public EntityTagElement(Map<String, String> parameters) {
         this.type = ElementParsingUtils.parseEntityType(parameters, "type", null);
         this.tag = ElementParsingUtils.parseTag(parameters, "tag", null);
         this.scale = ElementParsingUtils.parseFloat(parameters, "scale", 1.0f);
+        this.height = ElementParsingUtils.parseFloat(parameters, "height", 0.0f);
     }
 
     @Override
@@ -37,9 +39,12 @@ public class EntityTagElement implements TagElement {
                 }
             }
             if (entity instanceof LivingEntity living) {
+                if (height == 0.0f) {
+                    height = living.getBbHeight();
+                }
                 int blockScale = (int) ((BLOCK_HEIGHT * scale) + 0.5f);
                 int offsetX = x + (int) ((width / 2f) + 0.5f);
-                int offsetY = y + (int) ((blockScale * 2) + 0.5f);
+                int offsetY = y + (int) ((height * blockScale) + 0.5f);
                 int eyeOffset = offsetY - (int) ((living.getEyeHeight() * blockScale) + 0.5f);
                 InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, offsetX, offsetY, blockScale, offsetX - mouseX, eyeOffset - mouseY, living);
             }
@@ -48,6 +53,6 @@ public class EntityTagElement implements TagElement {
 
     @Override
     public int getHeight(int width) {
-        return (int) ((2 * BLOCK_HEIGHT * scale) + 3 + 0.5f);
+        return (int) ((height * BLOCK_HEIGHT * scale) + 3 + 0.5f);
     }
 }


### PR DESCRIPTION
0. (bonus) Eye following offset now uses entity.getEyeHeight().
1. `scale` attribute, a float, works as one might expect
2. `height` attribute, also a float, defaults to `0.0f`, as a flag value.
   If `height == 0.0f`, then hit-box height will be used.

Now, smaller entities won't take up unnecessary space, and entities taller than their hit-box can be accommodated for by the quest writer.

Example images follow:

Some pillagers at scales of 0.75, 1, and 1.5:

<img width="476" alt="Screenshot 2023-12-11 at 3 58 23 PM" src="https://github.com/terrarium-earth/Hermes/assets/6677700/ee3ed188-1dcd-4499-b92a-03fe6e56b5ee">


Vanilla mobs of varying visual height (the horse is visually taller than it's hit-box), no scaling, but all with height="2":
<img width="471" alt="Screenshot 2023-12-11 at 5 11 59 PM" src="https://github.com/terrarium-earth/Hermes/assets/6677700/98442fea-e643-4a75-990d-a2df84914f1d">



