### PR TITLE
Fill and borders for Image, Item, Entity, and Paragraph, Component, and H1|2 (TextTag's children)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ subprojects {
             }
         }
         repositories {
+            mavenLocal()
             maven {
                 url = "https://maven.resourcefulbees.com/repository/terrarium/"
                 credentials {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
@@ -34,7 +34,7 @@ public class ComponentTagElement extends TextTagElement {
         int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
         int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
 
-        drawBackground(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);
+        drawFillAndBorder(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);
 
         int lineHeight = font.lineHeight;
         for (int i = 0; i < lines.size(); i++) {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
@@ -12,9 +12,7 @@ import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.util.Mth;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class ComponentTagElement extends TextTagElement {
 
@@ -26,22 +24,34 @@ public class ComponentTagElement extends TextTagElement {
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
-        int height = 0;
+
         Component renderText = text.copy().setStyle(this.getStyle().applyTo(text.getStyle()));
-        for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(renderText, width - 10)) {
+        var font = Minecraft.getInstance().font;
+        var lines = font.split(renderText, width - 10);
+
+        var contentWidth = lines.stream().mapToInt((line) -> font.width(line) - 1).max().orElse(0);
+        // from top of top row capitals, to bottom of bottom row letters with descenders (eg: "y")
+        int contentHeight = (lines.size() * font.lineHeight) + (lines.size() - 2);
+        int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
+        int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
+
+        drawBackground(graphics, x + hSpacing + contentOffset, y + vSpacing, contentWidth, contentHeight);
+
+        int lineHeight = font.lineHeight;
+        for (int i = 0; i < lines.size(); i++) {
             graphics.drawString(
-                Minecraft.getInstance().font,
-                sequence,
-                x + getOffsetForTextTag(width, sequence),
-                y + height,
-                this.color.getValue(),
-                this.shadowed
+                    font,
+                    lines.get(i),
+                    x + hSpacing + lineOffsets[i],
+                    y + vSpacing + (i * (lineHeight + 1)),
+                    this.color.getValue(),
+                    this.shadowed
             );
-            height += Minecraft.getInstance().font.lineHeight + 1;
-            if (mouseY >= y + height || mouseY < y || !hovered) {
+
+            if (mouseY >= (y + vSpacing + contentHeight) || mouseY < (y + vSpacing) || !hovered) {
                 continue;
             }
-            renderComponentHoverEffect(Minecraft.getInstance().font.getSplitter().componentStyleAtWidth(sequence, Mth.floor(x - mouseX)));
+            renderComponentHoverEffect(font.getSplitter().componentStyleAtWidth(lines.get(i), Mth.floor(x - mouseX)));
         }
     }
 
@@ -57,7 +67,8 @@ public class ComponentTagElement extends TextTagElement {
     @Override
     public int getHeight(int width) {
         int lines = Minecraft.getInstance().font.split(this.text, width - 10).size();
-        return lines * (Minecraft.getInstance().font.lineHeight + 1);
+        int lineHeight = Minecraft.getInstance().font.lineHeight;
+        return ((lines * lineHeight) + (lines - 2)) + (2 * vSpacing); // element height + vertical spacing
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
@@ -26,7 +26,7 @@ public class ComponentTagElement extends TextTagElement {
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Component renderText = text.copy().setStyle(this.getStyle().applyTo(text.getStyle()));
         var font = Minecraft.getInstance().font;
-        var lines = font.split(renderText, width - (10 + (2 * hSpacing)));
+        var lines = font.split(renderText, width - (10 + (2 * xMargin)));
 
         var contentWidth = lines.stream().mapToInt((line) -> font.width(line) - 1).max().orElse(0);
         // from top of top row capitals, to bottom of bottom row letters with descenders (eg: "y")
@@ -34,20 +34,20 @@ public class ComponentTagElement extends TextTagElement {
         int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
         int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
 
-        drawBackground(graphics, x + hSpacing + contentOffset, y + vSpacing, contentWidth, contentHeight);
+        drawBackground(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);
 
         int lineHeight = font.lineHeight;
         for (int i = 0; i < lines.size(); i++) {
             graphics.drawString(
                     font,
                     lines.get(i),
-                    x + hSpacing + lineOffsets[i],
-                    y + vSpacing + (i * (lineHeight + 1)),
+                    x + xMargin + lineOffsets[i],
+                    y + yMargin + (i * (lineHeight + 1)),
                     this.color.getValue(),
                     this.shadowed
             );
 
-            if (mouseY >= (y + vSpacing + contentHeight) || mouseY < (y + vSpacing) || !hovered) {
+            if (mouseY >= (y + yMargin + contentHeight) || mouseY < (y + yMargin) || !hovered) {
                 continue;
             }
             renderComponentHoverEffect(font.getSplitter().componentStyleAtWidth(lines.get(i), Mth.floor(x - mouseX)));
@@ -65,9 +65,9 @@ public class ComponentTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(this.text, width - (10 + (2 * hSpacing))).size();
+        int lines = Minecraft.getInstance().font.split(this.text, width - (10 + (2 * xMargin))).size();
         int lineHeight = Minecraft.getInstance().font.lineHeight;
-        return ((lines * lineHeight) + (lines - 2)) + (2 * vSpacing); // element height + vertical spacing
+        return ((lines * lineHeight) + (lines - 2)) + (2 * yMargin); // element height + vertical spacing
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
@@ -26,7 +26,7 @@ public class ComponentTagElement extends TextTagElement {
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Component renderText = text.copy().setStyle(this.getStyle().applyTo(text.getStyle()));
         var font = Minecraft.getInstance().font;
-        var lines = font.split(renderText, width - (10 + (2 * xMargin)));
+        var lines = font.split(renderText, width - (10 + (2 * xSurround)));
 
         var contentWidth = lines.stream().mapToInt((line) -> font.width(line) - 1).max().orElse(0);
         // from top of top row capitals, to bottom of bottom row letters with descenders (eg: "y")
@@ -34,20 +34,20 @@ public class ComponentTagElement extends TextTagElement {
         int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
         int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
 
-        drawFillAndBorder(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);
+        drawFillAndBorder(graphics, x + xSurround + contentOffset, y + ySurround, contentWidth, contentHeight);
 
         int lineHeight = font.lineHeight;
         for (int i = 0; i < lines.size(); i++) {
             graphics.drawString(
                     font,
                     lines.get(i),
-                    x + xMargin + lineOffsets[i],
-                    y + yMargin + (i * (lineHeight + 1)),
+                    x + xSurround + lineOffsets[i],
+                    y + ySurround + (i * (lineHeight + 1)),
                     this.color.getValue(),
                     this.shadowed
             );
 
-            if (mouseY >= (y + yMargin + contentHeight) || mouseY < (y + yMargin) || !hovered) {
+            if (mouseY >= (y + ySurround + contentHeight) || mouseY < (y + ySurround) || !hovered) {
                 continue;
             }
             renderComponentHoverEffect(font.getSplitter().componentStyleAtWidth(lines.get(i), Mth.floor(x - mouseX)));
@@ -65,9 +65,9 @@ public class ComponentTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(this.text, width - (10 + (2 * xMargin))).size();
+        int lines = Minecraft.getInstance().font.split(this.text, width - (10 + (2 * xSurround))).size();
         int lineHeight = Minecraft.getInstance().font.lineHeight;
-        return ((lines * lineHeight) + (lines - 2)) + (2 * yMargin); // element height + vertical spacing
+        return ((lines * lineHeight) + (lines - 2)) + (2 * ySurround); // element height + vertical spacing
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ComponentTagElement.java
@@ -24,10 +24,9 @@ public class ComponentTagElement extends TextTagElement {
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
-
         Component renderText = text.copy().setStyle(this.getStyle().applyTo(text.getStyle()));
         var font = Minecraft.getInstance().font;
-        var lines = font.split(renderText, width - 10);
+        var lines = font.split(renderText, width - (10 + (2 * hSpacing)));
 
         var contentWidth = lines.stream().mapToInt((line) -> font.width(line) - 1).max().orElse(0);
         // from top of top row capitals, to bottom of bottom row letters with descenders (eg: "y")
@@ -66,7 +65,7 @@ public class ComponentTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(this.text, width - 10).size();
+        int lines = Minecraft.getInstance().font.split(this.text, width - (10 + (2 * hSpacing))).size();
         int lineHeight = Minecraft.getInstance().font.lineHeight;
         return ((lines * lineHeight) + (lines - 2)) + (2 * vSpacing); // element height + vertical spacing
     }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
@@ -69,10 +69,10 @@ public class EntityTagElement extends FillAndBorderElement implements TagElement
                 float layoutHeight = blockScale * layoutBlocksHigh;
                 float layoutWidth = blockScale * layoutBlocksWide;
 
-                int layoutX = x + xMargin + Alignment.getOffset(width, layoutWidth + (2 * xMargin), align);
+                int layoutX = x + xSurround + Alignment.getOffset(width, layoutWidth + (2 * xSurround), align);
                 int renderX = Math.round(layoutX + (layoutWidth / 2f));
 
-                int layoutY = y + yMargin;
+                int layoutY = y + ySurround;
                 int renderY = Math.round(layoutY + layoutHeight - (vShift * blockScale));
 
                 int eyeY = layoutY + Math.round(layoutHeight - (living.getEyeHeight() * blockScale));
@@ -87,7 +87,7 @@ public class EntityTagElement extends FillAndBorderElement implements TagElement
 
     @Override
     public int getHeight(int width) {
-        return Math.round((layoutBlocksHigh * scale * BLOCK_HEIGHT)) + (2 * yMargin); // (layoutHeight) + verticalPadding
+        return Math.round((layoutBlocksHigh * scale * BLOCK_HEIGHT)) + (2 * ySurround); // (layoutHeight) + verticalPadding
     }
 
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
@@ -69,10 +69,10 @@ public class EntityTagElement extends FillAndBorderElement implements TagElement
                 float layoutHeight = blockScale * layoutBlocksHigh;
                 float layoutWidth = blockScale * layoutBlocksWide;
 
-                int layoutX = x + spacing + Alignment.getOffset(width, layoutWidth + (2 * spacing), align);
+                int layoutX = x + hSpacing + Alignment.getOffset(width, layoutWidth + (2 * hSpacing), align);
                 int renderX = Math.round(layoutX + (layoutWidth / 2f));
 
-                int layoutY = y + spacing;
+                int layoutY = y + vSpacing;
                 int renderY = Math.round(layoutY + layoutHeight - (vShift * blockScale));
 
                 int eyeY = layoutY + Math.round(layoutHeight - (living.getEyeHeight() * blockScale));
@@ -87,7 +87,7 @@ public class EntityTagElement extends FillAndBorderElement implements TagElement
 
     @Override
     public int getHeight(int width) {
-        return Math.round((layoutBlocksHigh * scale * BLOCK_HEIGHT)) + (2 * spacing); // (layoutHeight) + verticalPadding
+        return Math.round((layoutBlocksHigh * scale * BLOCK_HEIGHT)) + (2 * vSpacing); // (layoutHeight) + verticalPadding
     }
 
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
@@ -69,10 +69,10 @@ public class EntityTagElement extends FillAndBorderElement implements TagElement
                 float layoutHeight = blockScale * layoutBlocksHigh;
                 float layoutWidth = blockScale * layoutBlocksWide;
 
-                int layoutX = x + hSpacing + Alignment.getOffset(width, layoutWidth + (2 * hSpacing), align);
+                int layoutX = x + xMargin + Alignment.getOffset(width, layoutWidth + (2 * xMargin), align);
                 int renderX = Math.round(layoutX + (layoutWidth / 2f));
 
-                int layoutY = y + vSpacing;
+                int layoutY = y + yMargin;
                 int renderY = Math.round(layoutY + layoutHeight - (vShift * blockScale));
 
                 int eyeY = layoutY + Math.round(layoutHeight - (living.getEyeHeight() * blockScale));
@@ -87,7 +87,7 @@ public class EntityTagElement extends FillAndBorderElement implements TagElement
 
     @Override
     public int getHeight(int width) {
-        return Math.round((layoutBlocksHigh * scale * BLOCK_HEIGHT)) + (2 * vSpacing); // (layoutHeight) + verticalPadding
+        return Math.round((layoutBlocksHigh * scale * BLOCK_HEIGHT)) + (2 * yMargin); // (layoutHeight) + verticalPadding
     }
 
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
@@ -14,28 +14,40 @@ import net.minecraft.world.entity.LivingEntity;
 
 import java.util.Map;
 
-public class EntityTagElement implements TagElement {
+public class EntityTagElement extends FillAndBorderElement implements TagElement {
 
     private final EntityType<?> type;
     private final CompoundTag tag;
     private final static int BLOCK_HEIGHT = 24;
     private final float scale;
-    private float entityBlocksHigh;
+    private float layoutBlocksHigh;
+    private final float vShift;
     private final Alignment align;
-    private float entityBlocksWide;
+    private float layoutBlocksWide;
     private Entity entity;
 
     public EntityTagElement(Map<String, String> parameters) {
+        super(parameters);
         this.type = ElementParsingUtils.parseEntityType(parameters, "type", null);
         this.tag = ElementParsingUtils.parseTag(parameters, "tag", null);
-        this.scale = ElementParsingUtils.parseFloat(parameters, "scale", 1.0f);
-        this.entityBlocksHigh = ElementParsingUtils.parseFloat(parameters, "height", 0.0f);
         this.align = ElementParsingUtils.parseAlignment(parameters, "align", Alignment.MIDDLE);
-        this.entityBlocksWide = ElementParsingUtils.parseFloat(parameters, "width", 0.0f);
+        this.scale = ElementParsingUtils.parseFloat(parameters, "scale", 1.0f);
+        this.vShift = ElementParsingUtils.parseFloat(parameters, "vshift", 0.0f);
+        this.layoutBlocksHigh = Math.abs(ElementParsingUtils.parseFloat(parameters, "height", 0.0f));
+        this.layoutBlocksWide = Math.abs(ElementParsingUtils.parseFloat(parameters, "width", 0.0f));
     }
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
+        /*
+        Note on layout and rendering of living entities:
+        Only the bounding box's dimensions are straight-forwardly available; the render call refers only to it.
+        However, several mobs' models visually exceed their bounding box. The horse and squid are two examples.
+        The 'width' and 'height' tag attributes affect the conceptual box that is implied by the layout.
+        The 'vshift' attribute shifts the render vertically in relation to actual bounding box; + is up, - is down.
+        The fill-able background area should correspond to the implied-by-layout box.
+        */
+
         if (this.type != null) {
             if (entity == null && Minecraft.getInstance().level != null) {
                 entity = this.type.create(Minecraft.getInstance().level);
@@ -46,28 +58,36 @@ public class EntityTagElement implements TagElement {
 
             if (entity instanceof LivingEntity living) {
 
-                if (entityBlocksHigh == 0.0f) {
-                    entityBlocksHigh = living.getBbHeight();
+                if (layoutBlocksHigh == 0.0f) {
+                    layoutBlocksHigh = living.getBbHeight();
                 }
-                if (entityBlocksWide == 0.0f) {
-                    entityBlocksWide = living.getBbWidth();
+                if (layoutBlocksWide == 0.0f) {
+                    layoutBlocksWide = living.getBbWidth();
                 }
 
                 int blockScale = Math.round(scale * BLOCK_HEIGHT);
-                float entityHeight = blockScale * entityBlocksHigh;
-                float entityWidth = blockScale * entityBlocksWide;
+                float layoutHeight = blockScale * layoutBlocksHigh;
+                float layoutWidth = blockScale * layoutBlocksWide;
 
-                int offsetX = Alignment.getOffsetCenterDrawnElement(width, entityWidth, align);
-                int offsetY = Math.round(entityHeight);
-                int eyeOffset = Math.round(entityHeight - (living.getEyeHeight() * blockScale));
+                int layoutX = x + Alignment.getOffset(width, layoutWidth, align);
+                int renderX = Math.round(layoutX + (layoutWidth / 2f));
 
-                InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, x + offsetX, y + offsetY + 1, blockScale, x + offsetX - mouseX, y + eyeOffset - mouseY, living);
+                int layoutY = y + verticalSpacing;
+                int renderY = Math.round(layoutY + layoutHeight - (vShift * blockScale));
+
+                int eyeY = layoutY + Math.round(layoutHeight - (living.getEyeHeight() * blockScale));
+                int lookX = renderX - mouseX;
+                int lookY = eyeY - mouseY;
+
+                drawBackground(graphics, layoutX, layoutY, layoutWidth, layoutHeight);
+                InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, renderX, renderY, blockScale, lookX, lookY, living);
             }
         }
     }
 
     @Override
     public int getHeight(int width) {
-        return Math.round((entityBlocksHigh * scale * BLOCK_HEIGHT) + 2);
+        return Math.round((layoutBlocksHigh * scale * BLOCK_HEIGHT)) + (2 * verticalSpacing); // (layoutHeight) + verticalPadding
     }
+
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
@@ -79,7 +79,7 @@ public class EntityTagElement extends FillAndBorderElement implements TagElement
                 int lookX = renderX - mouseX;
                 int lookY = eyeY - mouseY;
 
-                drawBackground(graphics, layoutX, layoutY, layoutWidth, layoutHeight);
+                drawFillAndBorder(graphics, layoutX, layoutY, layoutWidth, layoutHeight);
                 InventoryScreen.renderEntityInInventoryFollowsMouse(graphics, renderX, renderY, blockScale, lookX, lookY, living);
             }
         }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/EntityTagElement.java
@@ -69,10 +69,10 @@ public class EntityTagElement extends FillAndBorderElement implements TagElement
                 float layoutHeight = blockScale * layoutBlocksHigh;
                 float layoutWidth = blockScale * layoutBlocksWide;
 
-                int layoutX = x + Alignment.getOffset(width, layoutWidth, align);
+                int layoutX = x + spacing + Alignment.getOffset(width, layoutWidth + (2 * spacing), align);
                 int renderX = Math.round(layoutX + (layoutWidth / 2f));
 
-                int layoutY = y + verticalSpacing;
+                int layoutY = y + spacing;
                 int renderY = Math.round(layoutY + layoutHeight - (vShift * blockScale));
 
                 int eyeY = layoutY + Math.round(layoutHeight - (living.getEyeHeight() * blockScale));
@@ -87,7 +87,7 @@ public class EntityTagElement extends FillAndBorderElement implements TagElement
 
     @Override
     public int getHeight(int width) {
-        return Math.round((layoutBlocksHigh * scale * BLOCK_HEIGHT)) + (2 * verticalSpacing); // (layoutHeight) + verticalPadding
+        return Math.round((layoutBlocksHigh * scale * BLOCK_HEIGHT)) + (2 * spacing); // (layoutHeight) + verticalPadding
     }
 
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -23,8 +23,8 @@ public abstract class FillAndBorderElement implements TagElement {
     protected int borderWidth = 0;
     protected Color borderColor = ConstantColors.whitesmoke;
     protected boolean hasBorder = false;
-    protected int xMargin; // (background + borderWidth);
-    protected int yMargin; // 1 or (backgroundPadding + borderWidth)
+    protected int xSurround; // (background + borderWidth);
+    protected int ySurround; // 1 or (backgroundPadding + borderWidth)
 
     protected FillAndBorderElement(Map<String, String> parameters) {
         if (parameters.containsKey("background")) {
@@ -48,8 +48,8 @@ public abstract class FillAndBorderElement implements TagElement {
                     this.borderWidth = ElementParsingUtils.tryParse(borderSpecs[0], Integer::parseInt, borderWidth);
             }
         }
-        this.xMargin = backgroundPadding + borderWidth;
-        this.yMargin = Math.max(1, (backgroundPadding + borderWidth));
+        this.xSurround = backgroundPadding + borderWidth;
+        this.ySurround = Math.max(1, (backgroundPadding + borderWidth));
     }
 
     static int highPassAlpha(int color) {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -52,7 +52,7 @@ public abstract class FillAndBorderElement implements TagElement {
         this.yMargin = Math.max(1, (backgroundPadding + borderWidth));
     }
 
-    public void drawBackground(GuiGraphics graphics, int x, int y, float width, float height) {
+    public void drawFillAndBorder(GuiGraphics graphics, int x, int y, float width, float height) {
 
         IntFunction<Integer> no00Alpha = (c) -> (c >> 24) != 0 ? c : c + (0xFF << 24);
 

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -1,0 +1,74 @@
+package earth.terrarium.hermes.api.defaults;
+
+import com.teamresourceful.resourcefullib.common.color.Color;
+import com.teamresourceful.resourcefullib.common.color.ConstantColors;
+import earth.terrarium.hermes.api.TagElement;
+import earth.terrarium.hermes.utils.ElementParsingUtils;
+import net.minecraft.client.gui.GuiGraphics;
+
+import java.util.Map;
+import java.util.function.IntFunction;
+
+public abstract class FillAndBorderElement implements TagElement {
+
+    /* Only for background fills, not layout—though terms are borrowed from CSS's Box Model.
+    The area behind the element, plus any padding, may be filled with background color
+    A border may surround the padding area, with its own width and color. */
+
+    protected int backgroundPadding = 0;
+    protected Color backgroundColor = ConstantColors.gray;
+    protected boolean hasBackground = false;
+    protected int borderWidth = 1;
+    protected Color borderColor = ConstantColors.whitesmoke;
+    protected boolean hasBorder = false;
+
+    protected FillAndBorderElement(Map<String, String> parameters) {
+        if (parameters.containsKey("background")) {
+            this.hasBackground = true;
+            String[] backgroundSpecs = parameters.get("background").split(" ");
+            switch (backgroundSpecs.length) {
+                case 2:
+                    this.backgroundColor = ElementParsingUtils.tryParse(backgroundSpecs[1], Color::parse, backgroundColor);
+                case 1:
+                    this.backgroundPadding = ElementParsingUtils.tryParse(backgroundSpecs[0], Integer::parseInt, backgroundPadding);
+            }
+        }
+        if (parameters.containsKey("border")) {
+            this.hasBorder = true;
+            String[] borderSpecs = parameters.get("border").split(" ");
+            switch (borderSpecs.length) {
+                case 2:
+                    this.borderColor = ElementParsingUtils.tryParse(borderSpecs[1], Color::parse, borderColor);
+                case 1:
+                    this.borderWidth = ElementParsingUtils.tryParse(borderSpecs[0], Integer::parseInt, borderWidth);
+            }
+        }
+    }
+
+    public void drawBackground(GuiGraphics graphics, int x, int y, float width, float height) {
+
+        IntFunction<Integer> no00Alpha = (c) -> (c >> 24) != 0 ? c : c + (0xFF << 24);
+
+        int xA = x - backgroundPadding;
+        int yA = y - backgroundPadding;
+        int xB = Math.round(x + width + backgroundPadding);
+        int yB = Math.round(y + height + backgroundPadding);
+
+        if (hasBackground) {
+            graphics.fill(xA, yA, xB, yB, no00Alpha.apply(backgroundColor.getValue()));
+        }
+        if (hasBorder) {
+            int color = no00Alpha.apply(borderColor.getValue());
+
+            xA -= borderWidth; yA -= borderWidth;
+            xB += borderWidth; yB += borderWidth;
+            graphics.fill(xA, yA, xB, yA + borderWidth, color); // top
+            graphics.fill(xA, yB, xB, yB - borderWidth, color); // bottom
+
+            yA += borderWidth; yB -= borderWidth; // avoid over-lap in case color's alpha < 0xFF
+            graphics.fill(xA, yA, xA + borderWidth, yB, color); // left
+            graphics.fill(xB, yA, xB - borderWidth, yB, color); // right
+        }
+    }
+
+}

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -23,7 +23,7 @@ public abstract class FillAndBorderElement implements TagElement {
     protected int borderWidth = 0;
     protected Color borderColor = ConstantColors.whitesmoke;
     protected boolean hasBorder = false;
-    protected int verticalSpacing;
+    protected int spacing; // 1 or (backgroundPadding + borderWidth)
 
     protected FillAndBorderElement(Map<String, String> parameters) {
         if (parameters.containsKey("background")) {
@@ -47,7 +47,7 @@ public abstract class FillAndBorderElement implements TagElement {
                     this.borderWidth = ElementParsingUtils.tryParse(borderSpecs[0], Integer::parseInt, borderWidth);
             }
         }
-        this.verticalSpacing = Math.max(1, (backgroundPadding + borderWidth));
+        this.spacing = Math.max(1, (backgroundPadding + borderWidth));
     }
 
     public void drawBackground(GuiGraphics graphics, int x, int y, float width, float height) {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -23,8 +23,8 @@ public abstract class FillAndBorderElement implements TagElement {
     protected int borderWidth = 0;
     protected Color borderColor = ConstantColors.whitesmoke;
     protected boolean hasBorder = false;
-    protected int hSpacing; // (background + borderWidth);
-    protected int vSpacing; // 1 or (backgroundPadding + borderWidth)
+    protected int xMargin; // (background + borderWidth);
+    protected int yMargin; // 1 or (backgroundPadding + borderWidth)
 
     protected FillAndBorderElement(Map<String, String> parameters) {
         if (parameters.containsKey("background")) {
@@ -48,8 +48,8 @@ public abstract class FillAndBorderElement implements TagElement {
                     this.borderWidth = ElementParsingUtils.tryParse(borderSpecs[0], Integer::parseInt, borderWidth);
             }
         }
-        this.hSpacing = backgroundPadding + borderWidth;
-        this.vSpacing = Math.max(1, (backgroundPadding + borderWidth));
+        this.xMargin = backgroundPadding + borderWidth;
+        this.yMargin = Math.max(1, (backgroundPadding + borderWidth));
     }
 
     public void drawBackground(GuiGraphics graphics, int x, int y, float width, float height) {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -23,7 +23,8 @@ public abstract class FillAndBorderElement implements TagElement {
     protected int borderWidth = 0;
     protected Color borderColor = ConstantColors.whitesmoke;
     protected boolean hasBorder = false;
-    protected int spacing; // 1 or (backgroundPadding + borderWidth)
+    protected int hSpacing; // (background + borderWidth);
+    protected int vSpacing; // 1 or (backgroundPadding + borderWidth)
 
     protected FillAndBorderElement(Map<String, String> parameters) {
         if (parameters.containsKey("background")) {
@@ -47,7 +48,8 @@ public abstract class FillAndBorderElement implements TagElement {
                     this.borderWidth = ElementParsingUtils.tryParse(borderSpecs[0], Integer::parseInt, borderWidth);
             }
         }
-        this.spacing = Math.max(1, (backgroundPadding + borderWidth));
+        this.hSpacing = backgroundPadding + borderWidth;
+        this.vSpacing = Math.max(1, (backgroundPadding + borderWidth));
     }
 
     public void drawBackground(GuiGraphics graphics, int x, int y, float width, float height) {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -11,16 +11,19 @@ import java.util.function.IntFunction;
 
 public abstract class FillAndBorderElement implements TagElement {
 
-    /* Only for background fills, not layout—though terms are borrowed from CSS's Box Model.
+    /* For background fills and borders.
+    Though terms are borrowed from CSS's Box Model, does not change Hermes' layout model.
+    Does allow inheriting elements to be set taller and/or wider.
     The area behind the element, plus any padding, may be filled with background color
     A border may surround the padding area, with its own width and color. */
 
     protected int backgroundPadding = 0;
     protected Color backgroundColor = ConstantColors.gray;
     protected boolean hasBackground = false;
-    protected int borderWidth = 1;
+    protected int borderWidth = 0;
     protected Color borderColor = ConstantColors.whitesmoke;
     protected boolean hasBorder = false;
+    protected int verticalSpacing;
 
     protected FillAndBorderElement(Map<String, String> parameters) {
         if (parameters.containsKey("background")) {
@@ -35,6 +38,7 @@ public abstract class FillAndBorderElement implements TagElement {
         }
         if (parameters.containsKey("border")) {
             this.hasBorder = true;
+            this.borderWidth = 1; // Set a default value when the tag has a border attribute.
             String[] borderSpecs = parameters.get("border").split(" ");
             switch (borderSpecs.length) {
                 case 2:
@@ -43,6 +47,7 @@ public abstract class FillAndBorderElement implements TagElement {
                     this.borderWidth = ElementParsingUtils.tryParse(borderSpecs[0], Integer::parseInt, borderWidth);
             }
         }
+        this.verticalSpacing = Math.max(1, (backgroundPadding + borderWidth));
     }
 
     public void drawBackground(GuiGraphics graphics, int x, int y, float width, float height) {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -52,9 +52,11 @@ public abstract class FillAndBorderElement implements TagElement {
         this.yMargin = Math.max(1, (backgroundPadding + borderWidth));
     }
 
-    public void drawFillAndBorder(GuiGraphics graphics, int x, int y, float width, float height) {
+    static int highPassAlpha(int color) {
+        return (color >> 24) != 0 ? color : color + (0xFF << 24);
+    };
 
-        IntFunction<Integer> no00Alpha = (c) -> (c >> 24) != 0 ? c : c + (0xFF << 24);
+    public void drawFillAndBorder(GuiGraphics graphics, int x, int y, float width, float height) {
 
         int xA = x - backgroundPadding;
         int yA = y - backgroundPadding;
@@ -62,10 +64,10 @@ public abstract class FillAndBorderElement implements TagElement {
         int yB = Math.round(y + height + backgroundPadding);
 
         if (hasBackground) {
-            graphics.fill(xA, yA, xB, yB, no00Alpha.apply(backgroundColor.getValue()));
+            graphics.fill(xA, yA, xB, yB, highPassAlpha(backgroundColor.getValue()));
         }
         if (hasBorder) {
-            int color = no00Alpha.apply(borderColor.getValue());
+            int color = highPassAlpha(borderColor.getValue());
 
             xA -= borderWidth; yA -= borderWidth;
             xB += borderWidth; yB += borderWidth;

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -48,29 +48,27 @@ public abstract class FillAndBorderElement implements TagElement {
                     this.borderWidth = ElementParsingUtils.tryParse(borderSpecs[0], Integer::parseInt, borderWidth);
             }
         }
-        this.xSurround = backgroundPadding + borderWidth;
-        this.ySurround = Math.max(1, (backgroundPadding + borderWidth));
     }
 
     static int highPassAlpha(int color) {
         return (color >> 24) != 0 ? color : color + (0xFF << 24);
-    };
+    }
 
     public void drawFillAndBorder(GuiGraphics graphics, int x, int y, float width, float height) {
 
-        int xA = x - backgroundPadding;
-        int yA = y - backgroundPadding;
-        int xB = Math.round(x + width + backgroundPadding);
-        int yB = Math.round(y + height + backgroundPadding);
+        int x0 = x - backgroundPadding;
+        int y0 = y - backgroundPadding;
+        int x1 = Math.round(x + width + backgroundPadding);
+        int y1 = Math.round(y + height + backgroundPadding);
 
         if (hasBackground) {
-            graphics.fill(xA, yA, xB, yB, highPassAlpha(backgroundColor.getValue()));
+            graphics.fill(x0, y0, x1, y1, highPassAlpha(backgroundColor.getValue()));
         }
         if (hasBorder) {
             int color = highPassAlpha(borderColor.getValue());
-            xA -= borderWidth; yA -= borderWidth;
-            xB += borderWidth; yB += borderWidth;
-            RenderUtils.renderOutline(graphics, xA, yA, xB - xA, yB - yA, color, borderWidth);
+            x0 -= borderWidth; y0 -= borderWidth;
+            x1 += borderWidth; y1 += borderWidth;
+            RenderUtils.renderOutline(graphics, x0, y0, x1 - x0, y1 - y0, borderWidth, color);
         }
     }
 

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -48,6 +48,8 @@ public abstract class FillAndBorderElement implements TagElement {
                     this.borderWidth = ElementParsingUtils.tryParse(borderSpecs[0], Integer::parseInt, borderWidth);
             }
         }
+        this.xSurround = backgroundPadding + borderWidth;
+        this.ySurround = Math.max(1, (backgroundPadding + borderWidth));
     }
 
     static int highPassAlpha(int color) {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/FillAndBorderElement.java
@@ -4,10 +4,10 @@ import com.teamresourceful.resourcefullib.common.color.Color;
 import com.teamresourceful.resourcefullib.common.color.ConstantColors;
 import earth.terrarium.hermes.api.TagElement;
 import earth.terrarium.hermes.utils.ElementParsingUtils;
+import earth.terrarium.hermes.utils.RenderUtils;
 import net.minecraft.client.gui.GuiGraphics;
 
 import java.util.Map;
-import java.util.function.IntFunction;
 
 public abstract class FillAndBorderElement implements TagElement {
 
@@ -68,15 +68,9 @@ public abstract class FillAndBorderElement implements TagElement {
         }
         if (hasBorder) {
             int color = highPassAlpha(borderColor.getValue());
-
             xA -= borderWidth; yA -= borderWidth;
             xB += borderWidth; yB += borderWidth;
-            graphics.fill(xA, yA, xB, yA + borderWidth, color); // top
-            graphics.fill(xA, yB, xB, yB - borderWidth, color); // bottom
-
-            yA += borderWidth; yB -= borderWidth; // avoid over-lap in case color's alpha < 0xFF
-            graphics.fill(xA, yA, xA + borderWidth, yB, color); // left
-            graphics.fill(xB, yA, xB - borderWidth, yB, color); // right
+            RenderUtils.renderOutline(graphics, xA, yA, xB - xA, yB - yA, color, borderWidth);
         }
     }
 

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
@@ -29,7 +29,7 @@ public abstract class HeadingTagElement extends TextTagElement {
 
             Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             var font = Minecraft.getInstance().font;
-            var lines = font.split(text, (width - (10 + (2 * hSpacing))) / scale);
+            var lines = font.split(text, (width - (10 + (2 * xMargin))) / scale);
 
             var contentWidth = lines.stream().mapToInt((line) -> font.width(line) - 1).max().orElse(0);
             // from top of top row capitals, to bottom of bottom row letters with descenders (eg: "y")
@@ -37,15 +37,15 @@ public abstract class HeadingTagElement extends TextTagElement {
             int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
             int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
 
-            drawBackground(graphics, x + hSpacing + contentOffset, y + vSpacing, contentWidth, contentHeight);
+            drawBackground(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);;
 
             int lineHeight = font.lineHeight;
             for (int i = 0; i < lines.size(); i++) {
                 theme.drawText(
                         graphics,
                         lines.get(i),
-                        x + hSpacing + lineOffsets[i],
-                        y + vSpacing + (i * (lineHeight + 1)),
+                        x + xMargin + lineOffsets[i],
+                        y + yMargin + (i * (lineHeight + 1)),
                         this.color,
                         this.shadowed
                 );
@@ -55,15 +55,15 @@ public abstract class HeadingTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - (10 + (2 * hSpacing))) / scale).size();
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - (10 + (2 * xMargin))) / scale).size();
         int lineHeight = Minecraft.getInstance().font.lineHeight;
         // scale * (element height + vertical spacing)
-        return scale * (((lines * lineHeight) + (lines - 2)) + (2 * vSpacing));
+        return scale * (((lines * lineHeight) + (lines - 2)) + (2 * yMargin));
     }
 
     @Override
     public int getOffsetForTextTag(int width, FormattedCharSequence text) {
-        int textWidth = ((Minecraft.getInstance().font.width(text) - 1) + (2 * hSpacing)); // -1 to trim trailing empty space
+        int textWidth = ((Minecraft.getInstance().font.width(text) - 1) + (2 * xMargin)); // -1 to trim trailing empty space
         float scaledTextWidth = scale * textWidth;
         return Math.round((float) Alignment.getOffset(width, scaledTextWidth, align) / scale);
     }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
@@ -29,7 +29,7 @@ public abstract class HeadingTagElement extends TextTagElement {
 
             Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
             var font = Minecraft.getInstance().font;
-            var lines = font.split(text, (width - (10 + (2 * xMargin))) / scale);
+            var lines = font.split(text, (width - (10 + (2 * xSurround))) / scale);
 
             var contentWidth = lines.stream().mapToInt((line) -> font.width(line) - 1).max().orElse(0);
             // from top of top row capitals, to bottom of bottom row letters with descenders (eg: "y")
@@ -37,15 +37,15 @@ public abstract class HeadingTagElement extends TextTagElement {
             int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
             int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
 
-            drawFillAndBorder(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);;
+            drawFillAndBorder(graphics, x + xSurround + contentOffset, y + ySurround, contentWidth, contentHeight);;
 
             int lineHeight = font.lineHeight;
             for (int i = 0; i < lines.size(); i++) {
                 theme.drawText(
                         graphics,
                         lines.get(i),
-                        x + xMargin + lineOffsets[i],
-                        y + yMargin + (i * (lineHeight + 1)),
+                        x + xSurround + lineOffsets[i],
+                        y + ySurround + (i * (lineHeight + 1)),
                         this.color,
                         this.shadowed
                 );
@@ -55,15 +55,15 @@ public abstract class HeadingTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - (10 + (2 * xMargin))) / scale).size();
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - (10 + (2 * xSurround))) / scale).size();
         int lineHeight = Minecraft.getInstance().font.lineHeight;
         // scale * (element height + vertical spacing)
-        return scale * (((lines * lineHeight) + (lines - 2)) + (2 * yMargin));
+        return scale * (((lines * lineHeight) + (lines - 2)) + (2 * ySurround));
     }
 
     @Override
     public int getOffsetForTextTag(int width, FormattedCharSequence text) {
-        int textWidth = ((Minecraft.getInstance().font.width(text) - 1) + (2 * xMargin)); // -1 to trim trailing empty space
+        int textWidth = ((Minecraft.getInstance().font.width(text) - 1) + (2 * xSurround)); // -1 to trim trailing empty space
         float scaledTextWidth = scale * textWidth;
         return Math.round((float) Alignment.getOffset(width, scaledTextWidth, align) / scale);
     }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
@@ -55,7 +55,7 @@ public abstract class HeadingTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - 10) / scale).size();
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), (width - (10 + (2 * hSpacing))) / scale).size();
         int lineHeight = Minecraft.getInstance().font.lineHeight;
         // scale * (element height + vertical spacing)
         return scale * (((lines * lineHeight) + (lines - 2)) + (2 * vSpacing));

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/HeadingTagElement.java
@@ -37,7 +37,7 @@ public abstract class HeadingTagElement extends TextTagElement {
             int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
             int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
 
-            drawBackground(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);;
+            drawFillAndBorder(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);;
 
             int lineHeight = font.lineHeight;
             for (int i = 0; i < lines.size(); i++) {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ImageTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ImageTagElement.java
@@ -48,8 +48,8 @@ public class ImageTagElement extends FillAndBorderElement implements TagElement 
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
-        int xOffset = spacing + Alignment.getOffset(width, this.imageWidth + (2 * spacing), align);
-        int yOffset = spacing;
+        int xOffset = hSpacing + Alignment.getOffset(width, this.imageWidth + (2 * hSpacing), align);
+        int yOffset = vSpacing;
         drawBackground(graphics, x + xOffset, y + yOffset, imageWidth, imageHeight);
 
         if (this.imageTextureWidth == -1 && this.imageTextureHeight == -1) {
@@ -79,6 +79,6 @@ public class ImageTagElement extends FillAndBorderElement implements TagElement 
 
     @Override
     public int getHeight(int width) {
-        return this.imageHeight + (2 * spacing);
+        return this.imageHeight + (2 * vSpacing);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ImageTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ImageTagElement.java
@@ -48,8 +48,8 @@ public class ImageTagElement extends FillAndBorderElement implements TagElement 
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
-        int xOffset = hSpacing + Alignment.getOffset(width, this.imageWidth + (2 * hSpacing), align);
-        int yOffset = vSpacing;
+        int xOffset = xMargin + Alignment.getOffset(width, this.imageWidth + (2 * xMargin), align);
+        int yOffset = yMargin;
         drawBackground(graphics, x + xOffset, y + yOffset, imageWidth, imageHeight);
 
         if (this.imageTextureWidth == -1 && this.imageTextureHeight == -1) {
@@ -79,6 +79,6 @@ public class ImageTagElement extends FillAndBorderElement implements TagElement 
 
     @Override
     public int getHeight(int width) {
-        return this.imageHeight + (2 * vSpacing);
+        return this.imageHeight + (2 * yMargin);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ImageTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ImageTagElement.java
@@ -48,8 +48,8 @@ public class ImageTagElement extends FillAndBorderElement implements TagElement 
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
-        int xOffset = Alignment.getOffset(width, this.imageWidth, align);
-        int yOffset = verticalSpacing;
+        int xOffset = spacing + Alignment.getOffset(width, this.imageWidth + (2 * spacing), align);
+        int yOffset = spacing;
         drawBackground(graphics, x + xOffset, y + yOffset, imageWidth, imageHeight);
 
         if (this.imageTextureWidth == -1 && this.imageTextureHeight == -1) {
@@ -79,6 +79,6 @@ public class ImageTagElement extends FillAndBorderElement implements TagElement 
 
     @Override
     public int getHeight(int width) {
-        return this.imageHeight + (2 * verticalSpacing);
+        return this.imageHeight + (2 * spacing);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ImageTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ImageTagElement.java
@@ -48,8 +48,8 @@ public class ImageTagElement extends FillAndBorderElement implements TagElement 
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
-        int xOffset = xMargin + Alignment.getOffset(width, this.imageWidth + (2 * xMargin), align);
-        int yOffset = yMargin;
+        int xOffset = xSurround + Alignment.getOffset(width, this.imageWidth + (2 * xSurround), align);
+        int yOffset = ySurround;
         drawFillAndBorder(graphics, x + xOffset, y + yOffset, imageWidth, imageHeight);
 
         if (this.imageTextureWidth == -1 && this.imageTextureHeight == -1) {
@@ -79,6 +79,6 @@ public class ImageTagElement extends FillAndBorderElement implements TagElement 
 
     @Override
     public int getHeight(int width) {
-        return this.imageHeight + (2 * yMargin);
+        return this.imageHeight + (2 * ySurround);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ImageTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ImageTagElement.java
@@ -50,7 +50,7 @@ public class ImageTagElement extends FillAndBorderElement implements TagElement 
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         int xOffset = xMargin + Alignment.getOffset(width, this.imageWidth + (2 * xMargin), align);
         int yOffset = yMargin;
-        drawBackground(graphics, x + xOffset, y + yOffset, imageWidth, imageHeight);
+        drawFillAndBorder(graphics, x + xOffset, y + yOffset, imageWidth, imageHeight);
 
         if (this.imageTextureWidth == -1 && this.imageTextureHeight == -1) {
             blit(graphics, x + xOffset, y + yOffset, imageWidth, imageHeight);

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
@@ -35,8 +35,8 @@ public class ItemTagElement extends FillAndBorderElement implements TagElement {
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var pose = new CloseablePoseStack(graphics)) {
             float scaleSize = scale * 16;
-            int offsetX = xMargin + Alignment.getOffset(width, scaleSize + (2 * xMargin), align);
-            final int offsetY = yMargin;
+            int offsetX = xSurround + Alignment.getOffset(width, scaleSize + (2 * xSurround), align);
+            final int offsetY = ySurround;
             drawFillAndBorder(graphics, x + offsetX, y + offsetY, scaleSize, scaleSize);
             pose.translate(x + offsetX, y + offsetY, 0);
             pose.scale(scale, scale, 1.0F);
@@ -46,6 +46,6 @@ public class ItemTagElement extends FillAndBorderElement implements TagElement {
 
     @Override
     public int getHeight(int width) {
-        return Mth.ceil(16 * scale) + (2 * yMargin);
+        return Mth.ceil(16 * scale) + (2 * ySurround);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
@@ -14,13 +14,14 @@ import net.minecraft.world.item.Items;
 
 import java.util.Map;
 
-public class ItemTagElement implements TagElement {
+public class ItemTagElement extends FillAndBorderElement implements TagElement {
 
     protected final ItemStack output;
     protected final float scale;
     protected final Alignment align;
 
     public ItemTagElement(Map<String, String> parameters) {
+        super(parameters);
         Item item = ElementParsingUtils.parseItem(parameters, "id", Items.AIR);
         CompoundTag tag = ElementParsingUtils.parseTag(parameters, "tag", null);
         ItemStack stack = new ItemStack(item);
@@ -33,9 +34,11 @@ public class ItemTagElement implements TagElement {
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var pose = new CloseablePoseStack(graphics)) {
-            float scaleWidth = scale * 16;
-            int offsetX = Alignment.getOffset(width, scaleWidth, align);
-            pose.translate(x + offsetX, y + 1, 0);
+            float scaleSize = scale * 16;
+            int offsetX = Alignment.getOffset(width, scaleSize, align);
+            final int offsetY = verticalSpacing;
+            drawBackground(graphics, x + offsetX, y + offsetY, scaleSize, scaleSize);
+            pose.translate(x + offsetX, y + offsetY, 0);
             pose.scale(scale, scale, 1.0F);
             graphics.renderFakeItem(output, 0, 0);
         }
@@ -43,6 +46,6 @@ public class ItemTagElement implements TagElement {
 
     @Override
     public int getHeight(int width) {
-        return Mth.ceil(18 * scale);
+        return Mth.ceil(16 * scale) + (2 * verticalSpacing);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
@@ -35,8 +35,8 @@ public class ItemTagElement extends FillAndBorderElement implements TagElement {
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var pose = new CloseablePoseStack(graphics)) {
             float scaleSize = scale * 16;
-            int offsetX = Alignment.getOffset(width, scaleSize, align);
-            final int offsetY = verticalSpacing;
+            int offsetX = spacing + Alignment.getOffset(width, scaleSize + (2 * spacing), align);
+            final int offsetY = spacing;
             drawBackground(graphics, x + offsetX, y + offsetY, scaleSize, scaleSize);
             pose.translate(x + offsetX, y + offsetY, 0);
             pose.scale(scale, scale, 1.0F);
@@ -46,6 +46,6 @@ public class ItemTagElement extends FillAndBorderElement implements TagElement {
 
     @Override
     public int getHeight(int width) {
-        return Mth.ceil(16 * scale) + (2 * verticalSpacing);
+        return Mth.ceil(16 * scale) + (2 * spacing);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
@@ -35,8 +35,8 @@ public class ItemTagElement extends FillAndBorderElement implements TagElement {
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var pose = new CloseablePoseStack(graphics)) {
             float scaleSize = scale * 16;
-            int offsetX = hSpacing + Alignment.getOffset(width, scaleSize + (2 * hSpacing), align);
-            final int offsetY = vSpacing;
+            int offsetX = xMargin + Alignment.getOffset(width, scaleSize + (2 * xMargin), align);
+            final int offsetY = yMargin;
             drawBackground(graphics, x + offsetX, y + offsetY, scaleSize, scaleSize);
             pose.translate(x + offsetX, y + offsetY, 0);
             pose.scale(scale, scale, 1.0F);
@@ -46,6 +46,6 @@ public class ItemTagElement extends FillAndBorderElement implements TagElement {
 
     @Override
     public int getHeight(int width) {
-        return Mth.ceil(16 * scale) + (2 * vSpacing);
+        return Mth.ceil(16 * scale) + (2 * yMargin);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
@@ -35,8 +35,8 @@ public class ItemTagElement extends FillAndBorderElement implements TagElement {
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         try (var pose = new CloseablePoseStack(graphics)) {
             float scaleSize = scale * 16;
-            int offsetX = spacing + Alignment.getOffset(width, scaleSize + (2 * spacing), align);
-            final int offsetY = spacing;
+            int offsetX = hSpacing + Alignment.getOffset(width, scaleSize + (2 * hSpacing), align);
+            final int offsetY = vSpacing;
             drawBackground(graphics, x + offsetX, y + offsetY, scaleSize, scaleSize);
             pose.translate(x + offsetX, y + offsetY, 0);
             pose.scale(scale, scale, 1.0F);
@@ -46,6 +46,6 @@ public class ItemTagElement extends FillAndBorderElement implements TagElement {
 
     @Override
     public int getHeight(int width) {
-        return Mth.ceil(16 * scale) + (2 * spacing);
+        return Mth.ceil(16 * scale) + (2 * vSpacing);
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ItemTagElement.java
@@ -37,7 +37,7 @@ public class ItemTagElement extends FillAndBorderElement implements TagElement {
             float scaleSize = scale * 16;
             int offsetX = xMargin + Alignment.getOffset(width, scaleSize + (2 * xMargin), align);
             final int offsetY = yMargin;
-            drawBackground(graphics, x + offsetX, y + offsetY, scaleSize, scaleSize);
+            drawFillAndBorder(graphics, x + offsetX, y + offsetY, scaleSize, scaleSize);
             pose.translate(x + offsetX, y + offsetY, 0);
             pose.scale(scale, scale, 1.0F);
             graphics.renderFakeItem(output, 0, 0);

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
@@ -19,7 +19,7 @@ public class ParagraphTagElement extends TextTagElement {
 
         Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
         var font = Minecraft.getInstance().font;
-        var lines = font.split(text, width - (5 + (2 * xMargin)));
+        var lines = font.split(text, width - (5 + (2 * xSurround)));
 
         var contentWidth = lines.stream().mapToInt((line) -> font.width(line) - 1).max().orElse(0);
         // from top of top row capitals, to bottom of bottom row letters with descenders (eg: "y")
@@ -27,15 +27,15 @@ public class ParagraphTagElement extends TextTagElement {
         int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
         int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
 
-        drawFillAndBorder(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);
+        drawFillAndBorder(graphics, x + xSurround + contentOffset, y + ySurround, contentWidth, contentHeight);
 
         int lineHeight = font.lineHeight;
         for (int i = 0; i < lines.size(); i++) {
             theme.drawText(
                     graphics,
                     lines.get(i),
-                    x + xMargin + lineOffsets[i],
-                    y + yMargin + (i * (lineHeight + 1)),
+                    x + xSurround + lineOffsets[i],
+                    y + ySurround + (i * (lineHeight + 1)),
                     this.color,
                     this.shadowed
             );
@@ -44,8 +44,8 @@ public class ParagraphTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), width - (5 + (2 * xMargin))).size();
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), width - (5 + (2 * xSurround))).size();
         int lineHeight = Minecraft.getInstance().font.lineHeight;
-        return ((lines * lineHeight) + (lines - 2)) + (2 * yMargin); // element height + vertical spacing
+        return ((lines * lineHeight) + (lines - 2)) + (2 * ySurround); // element height + vertical spacing
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
@@ -4,36 +4,46 @@ import earth.terrarium.hermes.api.themes.Theme;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.FormattedCharSequence;
 
 import java.util.Map;
+import java.util.Arrays;
 
 public class ParagraphTagElement extends TextTagElement {
 
-    public ParagraphTagElement(Map<String, String> parameters) {
-        super(parameters);
-    }
+    public ParagraphTagElement(Map<String, String> parameters) { super(parameters); }
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
+
         Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
-        int height = 0;
-        for (FormattedCharSequence sequence : Minecraft.getInstance().font.split(text, width - 5)) {
+        var font = Minecraft.getInstance().font;
+        var lines = font.split(text, width - 5);
+
+        var contentWidth = lines.stream().mapToInt((line) -> font.width(line) - 1).max().orElse(0);
+        // from top of top row capitals, to bottom of bottom row letters with descenders (eg: "y")
+        int contentHeight = (lines.size() * font.lineHeight) + (lines.size() - 2);
+        int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
+        int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
+
+        drawBackground(graphics, x + hSpacing + contentOffset, y + vSpacing, contentWidth, contentHeight);
+
+        int lineHeight = font.lineHeight;
+        for (int i = 0; i < lines.size(); i++) {
             theme.drawText(
-                graphics,
-                sequence,
-                x + getOffsetForTextTag(width, sequence),
-                y + height,
-                this.color,
-                this.shadowed
+                    graphics,
+                    lines.get(i),
+                    x + hSpacing + lineOffsets[i],
+                    y + vSpacing + (i * (lineHeight + 1)),
+                    this.color,
+                    this.shadowed
             );
-            height += Minecraft.getInstance().font.lineHeight + 1;
         }
     }
 
     @Override
     public int getHeight(int width) {
         int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), width - 5).size();
-        return lines * (Minecraft.getInstance().font.lineHeight + 1);
+        int lineHeight = Minecraft.getInstance().font.lineHeight;
+        return ((lines * lineHeight) + (lines - 2)) + (2 * vSpacing); // element height + vertical spacing
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
@@ -17,7 +17,7 @@ public class ParagraphTagElement extends TextTagElement {
 
         Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
         var font = Minecraft.getInstance().font;
-        var lines = font.split(text, width - 5);
+        var lines = font.split(text, width - (5 + (2 * hSpacing)));
 
         var contentWidth = lines.stream().mapToInt((line) -> font.width(line) - 1).max().orElse(0);
         // from top of top row capitals, to bottom of bottom row letters with descenders (eg: "y")
@@ -42,7 +42,7 @@ public class ParagraphTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), width - 5).size();
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), width - (5 + (2 * hSpacing))).size();
         int lineHeight = Minecraft.getInstance().font.lineHeight;
         return ((lines * lineHeight) + (lines - 2)) + (2 * vSpacing); // element height + vertical spacing
     }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
@@ -10,7 +10,9 @@ import java.util.Arrays;
 
 public class ParagraphTagElement extends TextTagElement {
 
-    public ParagraphTagElement(Map<String, String> parameters) { super(parameters); }
+    public ParagraphTagElement(Map<String, String> parameters) {
+        super(parameters);
+    }
 
     @Override
     public void render(Theme theme, GuiGraphics graphics, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
@@ -25,7 +25,7 @@ public class ParagraphTagElement extends TextTagElement {
         int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
         int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
 
-        drawBackground(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);
+        drawFillAndBorder(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);
 
         int lineHeight = font.lineHeight;
         for (int i = 0; i < lines.size(); i++) {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/ParagraphTagElement.java
@@ -17,7 +17,7 @@ public class ParagraphTagElement extends TextTagElement {
 
         Component text = Component.nullToEmpty(this.content).copy().setStyle(this.getStyle());
         var font = Minecraft.getInstance().font;
-        var lines = font.split(text, width - (5 + (2 * hSpacing)));
+        var lines = font.split(text, width - (5 + (2 * xMargin)));
 
         var contentWidth = lines.stream().mapToInt((line) -> font.width(line) - 1).max().orElse(0);
         // from top of top row capitals, to bottom of bottom row letters with descenders (eg: "y")
@@ -25,15 +25,15 @@ public class ParagraphTagElement extends TextTagElement {
         int[] lineOffsets = lines.stream().mapToInt((line) -> getOffsetForTextTag(width, line)).toArray();
         int contentOffset = Arrays.stream(lineOffsets).min().orElse(width);
 
-        drawBackground(graphics, x + hSpacing + contentOffset, y + vSpacing, contentWidth, contentHeight);
+        drawBackground(graphics, x + xMargin + contentOffset, y + yMargin, contentWidth, contentHeight);
 
         int lineHeight = font.lineHeight;
         for (int i = 0; i < lines.size(); i++) {
             theme.drawText(
                     graphics,
                     lines.get(i),
-                    x + hSpacing + lineOffsets[i],
-                    y + vSpacing + (i * (lineHeight + 1)),
+                    x + xMargin + lineOffsets[i],
+                    y + yMargin + (i * (lineHeight + 1)),
                     this.color,
                     this.shadowed
             );
@@ -42,8 +42,8 @@ public class ParagraphTagElement extends TextTagElement {
 
     @Override
     public int getHeight(int width) {
-        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), width - (5 + (2 * hSpacing))).size();
+        int lines = Minecraft.getInstance().font.split(Component.nullToEmpty(this.content), width - (5 + (2 * xMargin))).size();
         int lineHeight = Minecraft.getInstance().font.lineHeight;
-        return ((lines * lineHeight) + (lines - 2)) + (2 * vSpacing); // element height + vertical spacing
+        return ((lines * lineHeight) + (lines - 2)) + (2 * yMargin); // element height + vertical spacing
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
@@ -57,7 +57,7 @@ public abstract class TextTagElement extends FillAndBorderElement implements Tag
 
     public int getOffsetForTextTag(int width, FormattedCharSequence text) {
         int textWidth = Minecraft.getInstance().font.width(text) - 1; // -1 to trim trailing empty space
-        return Alignment.getOffset(width, textWidth + (2 * xMargin), align);
+        return Alignment.getOffset(width, textWidth + (2 * xSurround), align);
     }
 
     public Style getStyle() {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
-public abstract class TextTagElement implements TagElement {
+public abstract class TextTagElement extends FillAndBorderElement implements TagElement {
 
     protected String content = "";
     protected @Nullable Boolean bold;
@@ -25,6 +25,7 @@ public abstract class TextTagElement implements TagElement {
     protected Color color;
 
     protected TextTagElement(Map<String, String> parameters) {
+        super(parameters);
         this.bold = parameters.containsKey("bold") ? Boolean.parseBoolean(parameters.get("bold")) : null;
         this.italic = parameters.containsKey("italic") ? Boolean.parseBoolean(parameters.get("italic")) : null;
         this.underline = parameters.containsKey("underline") ? Boolean.parseBoolean(parameters.get("underline")) : null;
@@ -55,8 +56,8 @@ public abstract class TextTagElement implements TagElement {
     }
 
     public int getOffsetForTextTag(int width, FormattedCharSequence text) {
-        int textWidth = Minecraft.getInstance().font.width(text) - 1;
-        return Alignment.getOffset(width, textWidth, align);
+        int textWidth = Minecraft.getInstance().font.width(text) - 1; // -1 to trim trailing empty space
+        return Alignment.getOffset(width, textWidth + (2 * hSpacing), align);
     }
 
     public Style getStyle() {

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextTagElement.java
@@ -57,7 +57,7 @@ public abstract class TextTagElement extends FillAndBorderElement implements Tag
 
     public int getOffsetForTextTag(int width, FormattedCharSequence text) {
         int textWidth = Minecraft.getInstance().font.width(text) - 1; // -1 to trim trailing empty space
-        return Alignment.getOffset(width, textWidth + (2 * hSpacing), align);
+        return Alignment.getOffset(width, textWidth + (2 * xMargin), align);
     }
 
     public Style getStyle() {

--- a/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
+++ b/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
 
 import java.util.Map;
+import java.util.function.Function;
 
 public final class ElementParsingUtils {
 
@@ -110,6 +111,14 @@ public final class ElementParsingUtils {
             }
         }
         return defaultValue;
+    }
+
+    public static <R> R tryParse(String input, Function<String, R> parseFunc, R defaultResult) {
+        try {
+            return parseFunc.apply(input);
+        } catch (Exception e) {
+            return defaultResult;
+        }
     }
 
 }

--- a/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
+++ b/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
@@ -6,8 +6,11 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.TagParser;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -111,6 +114,31 @@ public final class ElementParsingUtils {
             }
         }
         return defaultValue;
+    }
+
+    public static <A,B> @Nullable Tuple<A,B> parsePair(@NotNull Map<String, String> parameters,
+                                                       String key,
+                                                       Function<String, A> parserA, A defaultA,
+                                                       Function<String, B> parserB, B defaultB) {
+
+        Tuple<A,B> result = new Tuple<>(null,null);
+
+        if (!parameters.containsKey(key)) {
+            return null;
+        } else {
+            String[] spec = parameters.get(key).split(" ");
+            switch (spec.length) {
+                case 1 -> {
+                    result.setA(tryParse(spec[0], parserA, defaultA));
+                    result.setB(defaultB);
+                }
+                case 2 -> {
+                    result.setA(tryParse(spec[0], parserA, defaultA));
+                    result.setB(tryParse(spec[1], parserB, defaultB));
+                }
+            }
+            return result;
+        }
     }
 
     public static <R> R tryParse(String input, Function<String, R> parseFunc, R defaultResult) {

--- a/common/src/main/java/earth/terrarium/hermes/utils/RenderUtils.java
+++ b/common/src/main/java/earth/terrarium/hermes/utils/RenderUtils.java
@@ -4,13 +4,13 @@ import net.minecraft.client.gui.GuiGraphics;
 
 public final class RenderUtils {
 
-    public static void renderOutline(GuiGraphics graphics, int x, int y, int outerWidth, int outerHeight, int thickness, int color) {
+    public static void renderOutline(GuiGraphics graphics, int x, int y, int width, int height, int thickness, int color) {
 
         // Like graphics.renderOutline(), but also takes a thickness argument.
         // Outline segments are drawn to avoid over-lap in case color's alpha < 0xFF
 
-        int x0 = x; int x1 = x + outerWidth;
-        int y0 = y; int y1 = y + outerHeight;
+        int x0 = x; int x1 = x + width;
+        int y0 = y; int y1 = y + height;
         graphics.fill(x0, y0, x1, y0 + thickness, color); // top
         graphics.fill(x0, y1, x1, y1 - thickness, color); // bottom
 

--- a/common/src/main/java/earth/terrarium/hermes/utils/RenderUtils.java
+++ b/common/src/main/java/earth/terrarium/hermes/utils/RenderUtils.java
@@ -4,18 +4,18 @@ import net.minecraft.client.gui.GuiGraphics;
 
 public final class RenderUtils {
 
-    public static void renderOutline(GuiGraphics graphics, int x, int y, int outerWidth, int outerHeight, int color, int thickness) {
+    public static void renderOutline(GuiGraphics graphics, int x, int y, int outerWidth, int outerHeight, int thickness, int color) {
 
         // Like graphics.renderOutline(), but also takes a thickness argument.
         // Outline segments are drawn to avoid over-lap in case color's alpha < 0xFF
 
-        int xA = x; int xB = x + outerWidth;
-        int yA = y; int yB = y + outerHeight;
-        graphics.fill(xA, yA, xB, yA + thickness, color); // top
-        graphics.fill(xA, yB, xB, yB - thickness, color); // bottom
+        int x0 = x; int x1 = x + outerWidth;
+        int y0 = y; int y1 = y + outerHeight;
+        graphics.fill(x0, y0, x1, y0 + thickness, color); // top
+        graphics.fill(x0, y1, x1, y1 - thickness, color); // bottom
 
-        yA += thickness; yB -= thickness;
-        graphics.fill(xA, yA, xA + thickness, yB, color); // left
-        graphics.fill(xB, yA, xB - thickness, yB, color); // right
+        y0 += thickness; y1 -= thickness;
+        graphics.fill(x0, y0, x0 + thickness, y1, color); // left
+        graphics.fill(x1, y0, x1 - thickness, y1, color); // right
     }
 }

--- a/common/src/main/java/earth/terrarium/hermes/utils/RenderUtils.java
+++ b/common/src/main/java/earth/terrarium/hermes/utils/RenderUtils.java
@@ -1,0 +1,21 @@
+package earth.terrarium.hermes.utils;
+
+import net.minecraft.client.gui.GuiGraphics;
+
+public final class RenderUtils {
+
+    public static void renderOutline(GuiGraphics graphics, int x, int y, int outerWidth, int outerHeight, int color, int thickness) {
+
+        // Like graphics.renderOutline(), but also takes a thickness argument.
+        // Outline segments are drawn to avoid over-lap in case color's alpha < 0xFF
+
+        int xA = x; int xB = x + outerWidth;
+        int yA = y; int yB = y + outerHeight;
+        graphics.fill(xA, yA, xB, yA + thickness, color); // top
+        graphics.fill(xA, yB, xB, yB - thickness, color); // bottom
+
+        yA += thickness; yB -= thickness;
+        graphics.fill(xA, yA, xA + thickness, yB, color); // left
+        graphics.fill(xB, yA, xB - thickness, yB, color); // right
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ enabled_platforms=fabric,forge
 archives_base_name=hermes
 mod_id=hermes
 github_name=Hermes
-mod_version=1.4.0_sub0.1
+mod_version=1.4.0
 maven_group=earth.terrarium.hermes
 
 resourcefullib_version=2.0.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ enabled_platforms=fabric,forge
 archives_base_name=hermes
 mod_id=hermes
 github_name=Hermes
-mod_version=1.4.0
+mod_version=1.4.0_sub0.1
 maven_group=earth.terrarium.hermes
 
 resourcefullib_version=2.0.6


### PR DESCRIPTION
The affected tag elements gain two attributes, `background` and `border`, for specifying, respectively, padding and width; and also color for both.

Both of these expand the visual width and height of their element, and the element takes up that much space in the layout.
If no background padding or border are specified, the previous behavior of 1-high vertical spacing, above and below, and 0-wide horizontal spacing left and right, is maintained.

Origins: This patch arose from legibility questions I had, regarding the best way to design a theme. I made a survey of some mockups[^1]. This idea, using colored backgrounds to aid legibility of certain elements in a quest description—or just plain make them visually 'pop'—"won", though admittedly there were only a few respondents[^2].

It seemed useful and logical to extend this to the base text elements, `<p>`, `<component>`, and `<h1>` and `<h2>`[^3].

I tried to cover the details well in each commit message; I hope you don't mind me referring you, dear reviewer, to them.

[^1]: ![image](https://github.com/terrarium-earth/Hermes/assets/6677700/1d6ac4e8-1b4a-4f01-85f7-39dd9ce50ab4)
[^2]: https://discord.com/channels/570630340075454474/821417666332983306/1184302334474453074 ]
[^3]: <img width="586" alt="image" src="https://github.com/terrarium-earth/Hermes/assets/6677700/aac0425e-b289-465a-a321-3464a431f218">




