### PR TITLE
Adds <a> tag

### DIFF
--- a/common/src/main/java/earth/terrarium/hermes/api/DefaultTagProvider.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/DefaultTagProvider.java
@@ -12,6 +12,7 @@ import earth.terrarium.hermes.api.defaults.lists.UnorderedListTagElement;
 public class DefaultTagProvider extends TagProvider {
 
     public DefaultTagProvider() {
+        addSerializer("a", LinkTagElement::new);
         addSerializer("p", ParagraphTagElement::new);
         addSerializer("h1", HeadingOneTagElement::new);
         addSerializer("h2", HeadingTwoTagElement::new);

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/LinkTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/LinkTagElement.java
@@ -1,0 +1,35 @@
+package earth.terrarium.hermes.api.defaults;
+
+import earth.terrarium.hermes.utils.ElementParsingUtils;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URL;
+import java.util.Map;
+
+public class LinkTagElement extends ComponentTagElement {
+
+    protected String href;
+
+    public LinkTagElement(Map<String, String> parameters) {
+        super(parameters);
+        @Nullable URL url = ElementParsingUtils.parseURL(parameters, "href");
+        this.href = (url != null) ? url.toString() : "";
+    }
+
+    @Override
+    public void setContent(String content) {
+        try {
+            var linkText = String.format("\"text\":\"%s\"", content);
+            var linkClick = String.format("\"clickEvent\":{\"action\":\"open_url\",\"value\":\"%s\"}", href);
+            var linkHover = String.format("\"hoverEvent\": {\"action\": \"show_text\", \"value\":\"%s\"}", href);
+            var linkJson = "{" + String.join(",", linkText, linkHover, linkClick) + "}";
+            this.text = Component.Serializer.fromJson(linkJson);
+        } catch (Exception e) {
+            this.text = CommonComponents.EMPTY;
+        }
+    }
+    // <component>{"text":"This is a link","clickEvent":{"action":"open_url","value":"https://example.com"}}</component>
+}
+

--- a/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
+++ b/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
@@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
 
+import java.net.URL;
 import java.util.Map;
 
 public final class ElementParsingUtils {
@@ -99,6 +100,17 @@ public final class ElementParsingUtils {
             }
         }
         return defaultValue;
+    }
+
+    public static @Nullable URL parseURL(Map<String, String> parameters, String key) {
+        if (parameters.containsKey(key)) {
+            try {
+                return new URL(parameters.get(key));
+            } catch (Exception e) {
+                return null;
+            }
+        }
+        return null;
     }
 
     public static Alignment parseAlignment(Map<String, String> parameters, String key, Alignment defaultValue) {

--- a/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
+++ b/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
@@ -8,6 +8,7 @@ import net.minecraft.nbt.TagParser;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.URL;
 import java.util.Map;


### PR DESCRIPTION
Closes #6.

Implemented as a subclass of ComponentTagElement.

Overrides `setContent()` to set it's `Component text` to:
- have `text` be the user supplied text between `<a>` and `</a>`,
- have `hoverEvent` show the `href` attributes value,
- have `clickEvent` use `open_url` on `href` attribute.

Adds `parseURL()` to ElementParsingUtils.
- has no `default` parameter, but is @Nullable:
	- lets java.net.URL do the work of validating the user supplied href,
	- just going to use URL.toString() anyhow, cause that's what ultimately is needed by MC.

Of course, adds `addSerializer("a", LinkTagElement::new);` in DefaultTagProvider