### PR TITLE
Adds a <span> element and `style=""` attribute for compactly specifying multiple attributes.

### DIFF
--- a/common/src/main/java/earth/terrarium/hermes/api/TagProvider.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/TagProvider.java
@@ -1,6 +1,7 @@
 package earth.terrarium.hermes.api;
 
 import earth.terrarium.hermes.api.defaults.ParagraphTagElement;
+import earth.terrarium.hermes.utils.ElementParsingUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -100,6 +101,10 @@ public class TagProvider {
         for (int i = 0; i < map.getLength(); i++) {
             Node attribute = map.item(i);
             attributes.put(attribute.getNodeName(), attribute.getNodeValue());
+        }
+        if (attributes.containsKey("style")) {
+            var styleAttributes = ElementParsingUtils.parseStyleAttribute(attributes);
+            styleAttributes.forEach(attributes::putIfAbsent);
         }
         return attributes;
     }

--- a/common/src/main/java/earth/terrarium/hermes/api/text/TextTagElements.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/text/TextTagElements.java
@@ -1,6 +1,7 @@
 package earth.terrarium.hermes.api.text;
 
 import com.teamresourceful.resourcefullib.common.color.Color;
+import earth.terrarium.hermes.utils.ElementParsingUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
@@ -126,6 +127,18 @@ public final class TextTagElements {
         } catch (Exception ignored) {
             return new StyledTagElement(UnaryOperator.identity());
         }
+    }
+
+    public static ChildTextTagElement span(Map<String, String> parameters) {
+        return new StyledTagElement(style -> {
+            style = parameters.containsKey("bold") ? style.withBold(ElementParsingUtils.parseBoolean(parameters, "bold", false)) : style;
+            style = parameters.containsKey("italic") ? style.withItalic(ElementParsingUtils.parseBoolean(parameters, "italic", false)) : style;
+            style = parameters.containsKey("underline") ? style.withUnderlined(ElementParsingUtils.parseBoolean(parameters, "underline", false)) : style;
+            style = parameters.containsKey("obfuscated") ? style.withObfuscated(ElementParsingUtils.parseBoolean(parameters, "obfuscated", false)) : style;
+            style = parameters.containsKey("strikethrough") ? style.withStrikethrough(ElementParsingUtils.parseBoolean(parameters, "strikethrough", false)) : style;
+            style = parameters.containsKey("color") ? style.withColor(ElementParsingUtils.parseColor(parameters, "color", Color.DEFAULT).getValue()) : style;
+            return style;
+        });
     }
 
     public static ChildTextTagElement link(Map<String, String> parameters) {

--- a/common/src/main/java/earth/terrarium/hermes/api/text/TextTagProvider.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/text/TextTagProvider.java
@@ -49,6 +49,7 @@ public final class TextTagProvider extends TagProvider {
         addSerializer("reset", TextTagElements::reset);
 
         addSerializer("color", TextTagElements::color);
+        addSerializer("span", TextTagElements::span);
         addSerializer("link", TextTagElements::link);
         addSerializer("clipboard", TextTagElements::copyToClipboard);
 

--- a/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
+++ b/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
@@ -125,7 +125,7 @@ public final class ElementParsingUtils {
         // Example: style="!obfuscated,b,em,color:lavender,bg:0 #4a38d0"
 
         Map<String, String> result = new HashMap<>();
-        String[] specificers = parameters.get("style").split(",");
+        String[] specificers = parameters.get("style").split(";");
         String specValue;
         for (String specifier : specificers) {
             String[] specParts = specifier.split(":",2);

--- a/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
+++ b/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
@@ -11,6 +11,7 @@ import net.minecraft.world.item.Item;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -116,7 +117,48 @@ public final class ElementParsingUtils {
         return defaultValue;
     }
 
-    public static <A,B, C> @Nullable C parsePair(
+    public static Map<String, String> parseStyleAttribute(Map<String, String> parameters) {
+
+        // Allow for using 'style="..."' attribute values to compactly specify multiple attributes.
+        // These compact attributes may be in 'key:value' or boolean form.
+        // Booleans can be negated with a leading '!'; both forms may have short names or synonyms.
+        // Example: style="!obfuscated,b,em,color:lavender,bg:0 #4a38d0"
+
+        Map<String, String> result = new HashMap<>();
+        String[] specificers = parameters.get("style").split(",");
+        String specValue;
+        for (String specifier : specificers) {
+            String[] specParts = specifier.split(":",2);
+            if (specParts.length == 2) {
+                // key:value form
+                specifier = specParts[0];
+                specValue = specParts[1];
+            } else {
+                // boolean form
+                if (specifier.startsWith("!")) {
+                    specifier = specifier.substring(1);
+                    specValue = "false";
+                } else {
+                    specValue = "true";
+                }
+            }
+            // handle short names and synonyms
+            specifier = switch (specifier) {
+                case "i", "em" -> "italic";
+                case "b" -> "bold";
+                case "u" -> "underline";
+                case "st" -> "strikethrough";
+                case "obf" -> "obfuscated";
+                case "bg" -> "background";
+                case "brd" -> "border";
+                default -> specifier;
+            };
+            result.put(specifier, specValue);
+        }
+        return result;
+    }
+
+    public static <A, B, C> @Nullable C parsePair(
             @NotNull Map<String, String> parameters, String key, BiFunction<A, B, C> factory,
             Function<String, A> parserA, A defaultA, Function<String, B> parserB, B defaultB
     ) {

--- a/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
+++ b/common/src/main/java/earth/terrarium/hermes/utils/ElementParsingUtils.java
@@ -131,12 +131,13 @@ public final class ElementParsingUtils {
             String[] specParts = specifier.split(":",2);
             if (specParts.length == 2) {
                 // key:value form
-                specifier = specParts[0];
-                specValue = specParts[1];
+                specifier = specParts[0].strip();
+                specValue = specParts[1].strip();
             } else {
                 // boolean form
+                specifier = specifier.strip();
                 if (specifier.startsWith("!")) {
-                    specifier = specifier.substring(1);
+                    specifier = specifier.substring(1).strip();
                     specValue = "false";
                 } else {
                     specValue = "true";


### PR DESCRIPTION
ed03474:
Implements `<span>` tag element, as a ChildTextTagElement in TextTagElements.
Returns a StyledTagElement.

d0ac165:
In ElementParsingUtils, added: `parseStyleAttribute()`.
From the documenting comment:

> Allow for using `style="..."` attribute values to compactly specify multiple attributes.
> These compact attributes may be in 'key:value' or boolean form.
> Booleans can be negated with a leading '!'; both forms may have short names or synonyms.
> Example: `style="!obfuscated,b,em,color:lavender,bg:0 #4a38d0"`

In TagProvider's `mapAttributes()`:
- If current tag has a "style" attribute present:
	- parse it (via `parseStyleAttribute()` mentioned above)
	- insert these into attributes, via `putIfAbsent` so "normal" attributes take precedence.