### PR TITLE
TextContentTagElement styling

### DIFF
--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextContentTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextContentTagElement.java
@@ -1,6 +1,7 @@
 package earth.terrarium.hermes.api.defaults;
 
 import com.teamresourceful.resourcefullib.common.color.Color;
+import com.teamresourceful.resourcefullib.common.color.ConstantColors;
 import earth.terrarium.hermes.api.Alignment;
 import earth.terrarium.hermes.api.TagElement;
 import earth.terrarium.hermes.api.TagProvider;
@@ -24,11 +25,20 @@ public class TextContentTagElement extends FillAndBorderElement implements TagEl
 
     protected MutableComponent component = Component.empty();
     protected Alignment align;
+    protected boolean shadowed;
 
     public TextContentTagElement(Map<String, String> parameters) {
         super(parameters);
-
+        this.component.setStyle(Style.EMPTY
+                .withBold(ElementParsingUtils.parseBoolean(parameters, "bold", false))
+                .withItalic(ElementParsingUtils.parseBoolean(parameters, "italic", false))
+                .withUnderlined(ElementParsingUtils.parseBoolean(parameters, "underline", false))
+                .withObfuscated(ElementParsingUtils.parseBoolean(parameters, "obfuscated", false))
+                .withStrikethrough(ElementParsingUtils.parseBoolean(parameters, "strikethrough", false))
+                .withColor(ElementParsingUtils.parseColor(parameters, "color", Color.DEFAULT).getValue())
+        );
         this.align = ElementParsingUtils.parseAlignment(parameters, "align", Alignment.MIN);
+        this.shadowed = ElementParsingUtils.parseBoolean(parameters, "shadowed", false);
     }
 
     @Override
@@ -49,7 +59,7 @@ public class TextContentTagElement extends FillAndBorderElement implements TagEl
         int height = 0;
         for (FormattedCharSequence sequence : font.split(component, width - (5 + 2 * xSurround))) {
             int textOffset = getOffsetForTextTag(width, sequence);
-            theme.drawText(graphics, sequence, x + textOffset, y + height, Color.DEFAULT, false);
+            theme.drawText(graphics, sequence, x + textOffset, y + height, Color.DEFAULT, this.shadowed);
 
             if (actMouseX >= textOffset && actMouseX <= width && actMouseY >= height && actMouseY <= height + font.lineHeight) {
                 graphics.renderComponentHoverEffect(

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextContentTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextContentTagElement.java
@@ -37,7 +37,7 @@ public class TextContentTagElement extends FillAndBorderElement implements TagEl
                 .withColor(ElementParsingUtils.parseColor(parameters, "color", Color.DEFAULT).getValue())
         );
         this.align = ElementParsingUtils.parseAlignment(parameters, "align", Alignment.MIN);
-        this.shadowed = ElementParsingUtils.parseBoolean(parameters, "shadowed", false);
+        this.shadowed = ElementParsingUtils.parseBoolean(parameters, "shadowed", true);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextContentTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextContentTagElement.java
@@ -37,9 +37,9 @@ public class TextContentTagElement extends FillAndBorderElement implements TagEl
         y = y + ySurround;
 
         Font font = Minecraft.getInstance().font;
-        List<FormattedCharSequence> lines = font.split(component, width - 5);
+        List<FormattedCharSequence> lines = font.split(component, width - (5 + (2 * xSurround)));
         int maxWidth = lines.stream().mapToInt(font::width).max().orElse(0);
-        int maxHeight = lines.size() * (font.lineHeight + 1) + (lines.size() - 2);
+        int maxHeight = (lines.size() * font.lineHeight) + (lines.size() - 2);
         int offsetX = Alignment.getOffset(width, maxWidth + (2 * xSurround), align);
 
         drawFillAndBorder(graphics, x + offsetX, y, maxWidth, maxHeight);
@@ -47,9 +47,9 @@ public class TextContentTagElement extends FillAndBorderElement implements TagEl
         int actMouseX = mouseX - x;
         int actMouseY = mouseY - y;
         int height = 0;
-        for (FormattedCharSequence sequence : font.split(component, width - 5)) {
+        for (FormattedCharSequence sequence : font.split(component, width - (5 + 2 * xSurround))) {
             int textOffset = getOffsetForTextTag(width, sequence);
-            theme.drawText(graphics, sequence, x + textOffset, y + height, Color.DEFAULT, true);
+            theme.drawText(graphics, sequence, x + textOffset, y + height, Color.DEFAULT, false);
 
             if (actMouseX >= textOffset && actMouseX <= width && actMouseY >= height && actMouseY <= height + font.lineHeight) {
                 graphics.renderComponentHoverEffect(
@@ -84,8 +84,9 @@ public class TextContentTagElement extends FillAndBorderElement implements TagEl
     @Override
     public int getHeight(int width) {
         Font font = Minecraft.getInstance().font;
-        int lines = font.split(component, width - 5).size();
-        return lines * (font.lineHeight + 1);
+        int lines = font.split(component, width - (5 + (2 * xSurround))).size();
+        int lineHeight = font.lineHeight;
+        return ((lines * lineHeight) + (lines - 2)) + (2 * ySurround);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/hermes/api/defaults/TextContentTagElement.java
+++ b/common/src/main/java/earth/terrarium/hermes/api/defaults/TextContentTagElement.java
@@ -1,7 +1,6 @@
 package earth.terrarium.hermes.api.defaults;
 
 import com.teamresourceful.resourcefullib.common.color.Color;
-import com.teamresourceful.resourcefullib.common.color.ConstantColors;
 import earth.terrarium.hermes.api.Alignment;
 import earth.terrarium.hermes.api.TagElement;
 import earth.terrarium.hermes.api.TagProvider;


### PR DESCRIPTION
From a user stand-point, __this goes nicely with the feat/span-and-style PR__, imho.

From the main commit (f1f04c5):

> - initializer sets style on `this.component`, from styling parameters
> - shadow effect is rendered according to parameters

> This: `<text color="aqua" italic="true">One<blue><u>Two</u></blue>Three</text>`,
> will render as expected:

> 	- "One" and "Three" are aqua-colored,
>	- "Two" is blue and underlined,
>	-  all three worlds are italicized.

<img width="151" alt="image" src="https://github.com/terrarium-earth/Hermes/assets/6677700/4b06bdc4-9735-41df-b021-bfef70add9a7">

---
*Note: with the Span-and-Style PR (#23), the `<text>` tag's italic can be cancelled for an interval. Presumably this will work with the `<!italic>` style tags too, but they currently cause xml parse errors(Issue #22) on my dev machine.

`<text style='align:center,i,color:yellow'>fox <span style="!i,u,color:green">jumped</span> over</text>`

<img width="189" alt="image" src="https://github.com/terrarium-earth/Hermes/assets/6677700/5ec5c822-4d34-4d0c-8e9e-b3b41ad4d243">
