### PR TITLE
Fix minemark not shading into the common module and fix neoforge module.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,13 +81,13 @@ subprojects {
         api("org.commonmark:commonmark:$commonMarkVersion")
         api("dev.dediamondpro:minemark-core:$mineMarkVersion")
         implementation("com.cinemamod:mcef:$mcefVersion-$minecraftVersion")
+        shade("dev.dediamondpro:minemark-core:$mineMarkVersion")
 
         if (isCommon) {
             implementation("org.commonmark:commonmark-ext-gfm-strikethrough:$commonMarkVersion") { isTransitive = false }
             implementation("org.commonmark:commonmark-ext-gfm-tables:$commonMarkVersion") { isTransitive = false }
         } else {
             implementation("com.cinemamod:mcef-$modLoader:$mcefVersion-$minecraftVersion")
-            shade("dev.dediamondpro:minemark-core:$mineMarkVersion")
             shade("org.commonmark:commonmark-ext-gfm-strikethrough:$commonMarkVersion") { isTransitive = false }
             shade("org.commonmark:commonmark-ext-gfm-tables:$commonMarkVersion") { isTransitive = false }
         }
@@ -113,30 +113,30 @@ subprojects {
         }
     }
 
-    if (!isCommon) {
-        if (!isExtension) {
-            configure<ArchitectPluginExtension> {
-                platformSetupLoomIde()
-            }
+    if (!isCommon && !isExtension) {
+        configure<ArchitectPluginExtension> {
+            platformSetupLoomIde()
         }
+    }
 
-        val shadowCommon by configurations.creating {
-            isCanBeConsumed = false
-            isCanBeResolved = true
+
+    val shadowCommon by configurations.creating {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+    }
+
+    tasks {
+        "shadowJar"(ShadowJar::class) {
+            relocate("dev.dediamondpro.minemark", "earth.terrarium.hermes.libs.minemark")
+            relocate("org.commonmark", "earth.terrarium.hermes.libs.commonmark")
+            relocate("org.ccil.cowan.tagsoup", "earth.terrarium.hermes.libs.tagsoup")
+
+            archiveClassifier.set("dev-shadow")
+            configurations = listOf(shadowCommon, shade)
+
+            exclude("architectury.common.json")
         }
-
-        tasks {
-            "shadowJar"(ShadowJar::class) {
-                relocate("dev.dediamondpro.minemark", "earth.terrarium.hermes.libs.minemark")
-                relocate("org.commonmark", "earth.terrarium.hermes.libs.commonmark")
-                relocate("org.ccil.cowan.tagsoup", "earth.terrarium.hermes.libs.tagsoup")
-
-                archiveClassifier.set("dev-shadow")
-                configurations = listOf(shadowCommon, shade)
-
-                exclude("architectury.common.json")
-            }
-
+        afterEvaluate {
             "remapJar"(RemapJarTask::class) {
                 dependsOn("shadowJar")
                 inputFile.set(named<ShadowJar>("shadowJar").flatMap { it.archiveFile })

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader = "javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion = "[46,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion = "[2,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license = "MIT"
@@ -45,11 +45,11 @@ description = '''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
 [[dependencies.hermes]] #optional
 # the modid of the dependency
-modId = "forge" #mandatory
+modId = "neoforge" #mandatory
 # Does this dependency have to exist - if not, ordering below must be specified
 mandatory = true #mandatory
 # The version range of the dependency
-versionRange = "[46,)" #mandatory
+versionRange = "[21,)" #mandatory
 # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
 ordering = "NONE"
 # Side this dependency is applied on - BOTH, CLIENT or SERVER
@@ -59,6 +59,6 @@ side = "BOTH"
 modId = "minecraft"
 mandatory = true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
-versionRange = "[1.20,)"
+versionRange = "[1.21.1,)"
 ordering = "NONE"
 side = "BOTH"


### PR DESCRIPTION
Fixes the minemark dependency not shading into the common module to be relocated like the neoforge and fabric modules.
Rename mods.toml to neoforge.mods.toml.
Fix versioning in neoforge.mods.toml.

This was needed for downstream projects such as [Heracles](https://github.com/terrarium-earth/Heracles/tree/1.21.1)